### PR TITLE
Fix problem with identically named channels

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -549,9 +549,7 @@ ircClient.on('PRIVMSG', (response) => {
   const { channelName, message, timestamp } = response;
 
   // Find the server and channel
-  const server = useStore.getState().servers.find(s =>
-    s.channels.some(c => c.name === channelName)
-  );
+  const server = useStore.getState().servers.find(s => s.id === response.serverId);
 
   if (server) {
     const channel = server.channels.find(c => c.name === channelName);


### PR DESCRIPTION
This fixes a problem where sent messages would show up in the wrong channel on the wrong server where the channel name was identical. this is due to looking up the server incorrectly.