### PR TITLE
Fix: Default channels should be preserved

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ const initializeEnvSettings = (
     isOpen?: boolean,
     prefillDetails?: ConnectionDetails | null,
   ) => void,
+  joinChannel: (serverId: string, channelName: string) => void,
 ) => {
   if (loadSavedServers().length > 0) return;
   const host = __DEFAULT_IRC_SERVER__
@@ -57,7 +58,7 @@ const initializeEnvSettings = (
   ircClient.on("ready", ({ serverId, serverName, nickname }) => {
     // Automatically join default channels
     for (const channel of __DEFAULT_IRC_CHANNELS__) {
-      ircClient.joinChannel(serverId, channel);
+      joinChannel(serverId, channel);
     }
   });
 };
@@ -66,11 +67,12 @@ const App: React.FC = () => {
   const {
     toggleAddServerModal,
     ui: { isAddServerModalOpen, isUserProfileModalOpen },
+    joinChannel,
   } = useStore();
   // askPermissions();
   useEffect(() => {
-    initializeEnvSettings(toggleAddServerModal);
-  }, [toggleAddServerModal]);
+    initializeEnvSettings(toggleAddServerModal, joinChannel);
+  }, [toggleAddServerModal, joinChannel]);
 
   return (
     <div className="h-screen overflow-hidden">


### PR DESCRIPTION
When starting with a default channel, they are not preserved.

Should use state manager method instead of irc client directly as it manages local storage.
