### PR TITLE
manually publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,10 +6,11 @@ on:
       - main
     tags:
       - "v*.*.*"
+  workflow_dispatch:
 
 jobs:
   collect-version:
-    if: github.ref_name == 'main' || github.ref_type == 'tag'
+    if: github.ref_name == 'main' || github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     outputs:
       current_version: ${{ steps.package-version.outputs.version }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled manual triggering of the publish workflow from GitHub Actions, allowing on-demand runs (e.g., for hotfixes or urgent releases) without waiting for automatic triggers.
  * Updated workflow conditions so version information is properly collected during manual runs, ensuring consistent release metadata.
  * Improves operational control and flexibility for release management with no impact on application behavior or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->