### PR TITLE
ircClient: Support replies on multiline messages

### DIFF
--- a/src/hooks/useMessageSending.ts
+++ b/src/hooks/useMessageSending.ts
@@ -103,7 +103,7 @@ export function useMessageSending({
 
       const batchId = createBatchId();
       const replyPrefix = localReplyTo
-        ? `@+draft/reply=${localReplyTo.msgid};`
+        ? `@+draft/reply=${localReplyTo.msgid} `
         : "";
 
       ircClient.sendRaw(

--- a/src/lib/ircClient.ts
+++ b/src/lib/ircClient.ts
@@ -385,6 +385,7 @@ export class IRCClient {
         timestamps?: Date[];
         batchMsgId?: string;
         batchTime?: Date;
+        replyId?: string;
       }
     >
   > = new Map(); // Track active batches per server
@@ -1770,6 +1771,7 @@ export class IRCClient {
             messageIds: [],
             batchMsgId: mtags?.msgid, // Store the msgid from the BATCH command itself
             batchTime: mtags?.time ? new Date(mtags.time) : undefined, // Store the time from the BATCH command
+            replyId: mtags?.["+draft/reply"],
           });
 
           this.triggerEvent("BATCH_START", {
@@ -1814,9 +1816,13 @@ export class IRCClient {
               }
             });
 
+            const batchMtags: Record<string, string> = {};
+            if (batch.batchMsgId) batchMtags.msgid = batch.batchMsgId; // Use the msgid from the BATCH command
+            if (batch.replyId) batchMtags["+draft/reply"] = batch.replyId;
+
             this.triggerEvent("MULTILINE_MESSAGE", {
               serverId,
-              mtags: batch.batchMsgId ? { msgid: batch.batchMsgId } : undefined, // Use the msgid from the BATCH command
+              mtags: batchMtags,
               sender,
               channelName: target.startsWith("#") ? target : undefined,
               message: combinedMessage,


### PR DESCRIPTION
Little bug I encountered while trying to implement replies in some other
IRC client

To reproduce the bug

1. Send a message
2. Try replying to that message with a multiline message

Ideally the new message should be displayed and show the replied message


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected reply header formatting in multiline message handling to maintain protocol compatibility.
  * Enhanced multiline message event emissions to properly include reply identification and draft-reply context metadata.

* **Tests**
  * Added test coverage for multiline message event handling, verifying proper inclusion of reply metadata and message reconstruction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->