### PR TITLE
modals should focus chat input on exit

### DIFF
--- a/src/components/layout/ChatArea.tsx
+++ b/src/components/layout/ChatArea.tsx
@@ -175,6 +175,18 @@ export const ChatArea: React.FC<{
   const kickUser = useStore((state) => state.kickUser);
   const banUserByNick = useStore((state) => state.banUserByNick);
   const banUserByHostmask = useStore((state) => state.banUserByHostmask);
+  const clearChatInputFocus = useStore((state) => state.clearChatInputFocus);
+  const shouldFocusChatInput = useStore(
+    (state) => state.ui.shouldFocusChatInput,
+  );
+
+  // Focus chat input when requested by other components (e.g., modals closing)
+  useEffect(() => {
+    if (shouldFocusChatInput && inputRef.current) {
+      inputRef.current.focus();
+      clearChatInputFocus();
+    }
+  }, [shouldFocusChatInput, clearChatInputFocus]);
 
   const selectedServerId = ui.selectedServerId;
   const currentSelection = ui.perServerSelections[selectedServerId || ""] || {

--- a/src/components/ui/QuickActions.tsx
+++ b/src/components/ui/QuickActions.tsx
@@ -50,6 +50,7 @@ const QuickActions: React.FC = () => {
     selectServer,
     joinChannel,
     openPrivateChat,
+    requestChatInputFocus,
   } = useStore();
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -59,7 +60,8 @@ const QuickActions: React.FC = () => {
     toggleQuickActions(false);
     setSearchQuery("");
     setSelectedIndex(0);
-  }, [toggleQuickActions]);
+    requestChatInputFocus();
+  }, [toggleQuickActions, requestChatInputFocus]);
 
   const searchResults: QuickActionResult[] = useMemo(() => {
     const query = searchQuery.trim();

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -419,6 +419,8 @@ interface UIState {
   } | null;
   // Shimmer effect for newly connected servers
   serverShimmer?: Set<string>; // Set of server IDs that should show shimmer
+  // Request focus on chat input (used when closing modals)
+  shouldFocusChatInput: boolean;
 }
 
 export interface GlobalSettings {
@@ -672,6 +674,8 @@ export interface AppState {
   toggleEditServerModal: (isOpen?: boolean, serverId?: string | null) => void;
   toggleSettingsModal: (isOpen?: boolean) => void;
   toggleQuickActions: (isOpen?: boolean) => void;
+  requestChatInputFocus: () => void;
+  clearChatInputFocus: () => void;
   toggleUserProfileModal: (isOpen?: boolean) => void;
   setProfileViewRequest: (serverId: string, username: string) => void;
   clearProfileViewRequest: () => void;
@@ -832,6 +836,8 @@ const useStore = create<AppState>((set, get) => ({
     profileViewRequest: null,
     // Settings navigation
     settingsNavigation: null,
+    // Chat input focus request
+    shouldFocusChatInput: false,
   },
   globalSettings: {
     enableNotifications: false,
@@ -2277,6 +2283,18 @@ const useStore = create<AppState>((set, get) => ({
         isQuickActionsOpen:
           isOpen !== undefined ? isOpen : !state.ui.isQuickActionsOpen,
       },
+    }));
+  },
+
+  requestChatInputFocus: () => {
+    set((state) => ({
+      ui: { ...state.ui, shouldFocusChatInput: true },
+    }));
+  },
+
+  clearChatInputFocus: () => {
+    set((state) => ({
+      ui: { ...state.ui, shouldFocusChatInput: false },
     }));
   },
 

--- a/tests/components/ChatArea.test.tsx
+++ b/tests/components/ChatArea.test.tsx
@@ -98,6 +98,7 @@ describe("ChatArea Tab Completion Integration", () => {
         serverNoticesPopupMinimized: false,
         profileViewRequest: null,
         settingsNavigation: null,
+        shouldFocusChatInput: false,
       },
       messages: {},
       typingUsers: {},

--- a/tests/components/MetadataDisplay.test.tsx
+++ b/tests/components/MetadataDisplay.test.tsx
@@ -160,6 +160,7 @@ describe("Metadata Display Features", () => {
         serverNoticesPopupMinimized: false,
         profileViewRequest: null,
         settingsNavigation: null,
+        shouldFocusChatInput: false,
       },
       messages: {
         "server1-channel1": mockChannel.messages,

--- a/tests/lib/nicknameRetry.test.ts
+++ b/tests/lib/nicknameRetry.test.ts
@@ -69,6 +69,7 @@ describe("Nickname retry functionality", () => {
         serverNoticesPopupMinimized: false,
         profileViewRequest: null,
         settingsNavigation: null,
+        shouldFocusChatInput: false,
       },
       addGlobalNotification: vi.fn(),
     };
@@ -165,6 +166,7 @@ describe("Nickname retry functionality", () => {
         serverNoticesPopupMinimized: false,
         profileViewRequest: null,
         settingsNavigation: null,
+        shouldFocusChatInput: false,
       },
       addGlobalNotification: vi.fn(),
     };

--- a/tests/protocol/mode.test.ts
+++ b/tests/protocol/mode.test.ts
@@ -54,6 +54,7 @@ describe("MODE Protocol Handler", () => {
         serverNoticesPopupMinimized: false,
         profileViewRequest: null,
         settingsNavigation: null,
+        shouldFocusChatInput: false,
       },
     });
     vi.clearAllMocks();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Chat input now automatically receives focus when closing UI elements and modals, streamlining the user interaction flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->