### PR TITLE
Fix reconnection to Ergo servers on web client

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -66,7 +66,7 @@ function ensureUrlFormat(host: string, port: number): string {
     host === "localhost" || host === "127.0.0.1" || host === "::1";
   const scheme = isLocalhost
     ? "ws"
-    : port === 6697 || port === 9999 || port === 443 || port === 993
+    : port === 6697 || port === 9999 || port === 443 || port === 993 || port === 8097
       ? "wss"
       : "ws";
   return `${scheme}://${host}:${port}`;


### PR DESCRIPTION
Resolves #139 by adding Ergo IRCd's default secure websocket port 8097 to the list of ports automatically marked as wss:// in ensureUrlFormat().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced WebSocket connection security by ensuring port 8097 uses encrypted secure connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->