### PR TITLE
Fix the reconnection issue for websocket ports outside predefined ones

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -61,14 +61,14 @@ function ensureUrlFormat(host: string, port: number): string {
   if (host.includes("://")) {
     return host; // Already in URL format
   }
-  // Convert old hostname-only format to URL
+  // Heuristic guess to decide if we should use a secure connection
+  // if the host was entered without a URL prefix
+  // Insecure connections aren't allowed outside localhost
   const isLocalhost =
     host === "localhost" || host === "127.0.0.1" || host === "::1";
   const scheme = isLocalhost
     ? "ws"
-    : port === 6697 || port === 9999 || port === 443 || port === 993
-      ? "wss"
-      : "ws";
+    : "wss";
   return `${scheme}://${host}:${port}`;
 }
 


### PR DESCRIPTION
Resolves issue https://github.com/ObsidianIRC/ObsidianIRC/issues/139 as per [matheusfillipe](https://github.com/matheusfillipe)'s recommendation in PR https://github.com/ObsidianIRC/ObsidianIRC/pull/140, which has been silent for a week now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced WebSocket connection handling for improved consistency between local and remote environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->