### PR TITLE
Bug fix: Underscores are not allowed in batch IDs as per the batch spec

### DIFF
--- a/src/lib/messageProtocol.ts
+++ b/src/lib/messageProtocol.ts
@@ -87,5 +87,5 @@ export const calculateProtocolOverhead = (target: string): number => {
  * @returns A unique batch identifier
  */
 export const createBatchId = (): string => {
-  return `ml_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+  return `ml-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
 };

--- a/src/lib/messageProtocol.ts
+++ b/src/lib/messageProtocol.ts
@@ -29,7 +29,7 @@ export const splitLongMessage = (
     if (word.length > maxMessageLength) {
       // If a single word is too long, we have to break it
       if (currentLine) {
-        lines.push(currentLine.trim());
+        lines.push(currentLine);
         currentLine = "";
       }
 
@@ -40,7 +40,7 @@ export const splitLongMessage = (
     } else if (`${currentLine} ${word}`.length > maxMessageLength) {
       // Adding this word would exceed the limit
       if (currentLine) {
-        lines.push(currentLine.trim());
+        lines.push(currentLine);
       }
       currentLine = word;
     } else {
@@ -49,7 +49,7 @@ export const splitLongMessage = (
   }
 
   if (currentLine) {
-    lines.push(currentLine.trim());
+    lines.push(currentLine);
   }
 
   return lines.filter((line) => line.length > 0);


### PR DESCRIPTION
From https://ircv3.net/specs/extensions/batch
> The reference tag MUST be treated as an opaque identifier. Reference tag MUST contain only ASCII letters, numbers, and/or hyphen, and MUST be case-sensitive.

Discovered thanks to UnrealIRCd's implementation which correctly told us we're doing it wrong. Means Ergo has a bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed message segment processing to properly preserve whitespace formatting in message chunks
* **Style**
  * Updated batch identifier format for improved consistency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->