### PR TITLE
feat: multi-file uploads, progress overlay, batched send

### DIFF
--- a/src/components/layout/ChatArea.tsx
+++ b/src/components/layout/ChatArea.tsx
@@ -17,6 +17,11 @@ import { useTypingNotification } from "../../hooks/useTypingNotification";
 import ircClient from "../../lib/ircClient";
 import { parseIrcUrl } from "../../lib/ircUrlParser";
 import {
+  fetchUploadInfo,
+  uploadFile,
+  validateFileAgainstInfo,
+} from "../../lib/mediaUpload";
+import {
   type FormattingType,
   getPreviewStyles,
   isValidFormattingType,
@@ -44,6 +49,10 @@ import ReactionModal from "../ui/ReactionModal";
 import { ReactionPopover } from "../ui/ReactionPopover";
 import { TextArea } from "../ui/TextInput";
 import { TopicMediaStrip } from "../ui/TopicMediaStrip";
+import {
+  type UploadJob,
+  UploadProgressOverlay,
+} from "../ui/UploadProgressOverlay";
 import UserContextMenu from "../ui/UserContextMenu";
 import UserProfileModal from "../ui/UserProfileModal";
 import {
@@ -130,6 +139,11 @@ export const ChatArea: React.FC<{
     file: null,
     previewUrl: null,
   });
+  // Multimedia uploads in flight.  Each job tracks one file's
+  // XHR-driven progress; once they all settle we send a single
+  // PRIVMSG with the URLs joined.
+  const [uploadJobs, setUploadJobs] = useState<UploadJob[]>([]);
+  const uploadAbortsRef = useRef<Map<string, AbortController>>(new Map());
   const [isServerNoticesPoppedOut, setIsServerNoticesPoppedOut] =
     useState(false);
   const [serverNoticesPopupPosition, setServerNoticesPopupPosition] = useState({
@@ -964,6 +978,145 @@ export const ChatArea: React.FC<{
       console.error("Image upload failed:", error);
       // TODO: Show error to user
     }
+  };
+
+  // Multi-file upload entry point.  Picks up an auth token (one-shot
+  // per batch -- the backend accepts the same token across many
+  // uploads), kicks off N uploads in parallel, surfaces per-file
+  // progress, and on full success sends a single PRIVMSG containing
+  // all the resulting URLs separated by spaces.
+  const handleFilesUpload = async (files: File[]) => {
+    if (!selectedServer?.filehost || !selectedServerId || files.length === 0) {
+      return;
+    }
+    const filehostUrl = selectedServer.filehost;
+    const target = selectedChannel?.name ?? selectedPrivateChat?.username;
+    if (!target) return;
+
+    // Pre-flight: pull the policy so we can reject obviously-bad
+    // files before pushing bytes.
+    const info = await fetchUploadInfo(filehostUrl);
+
+    // Acquire auth token (reuse existing EXTJWT flow).  The backend
+    // doesn't need a fresh token per file -- the same Bearer is
+    // accepted until expiry, so we mint once.
+    let jwtToken = selectedServer?.jwtToken;
+    if (!jwtToken) {
+      useStore.setState((state) => ({
+        servers: state.servers.map((server) =>
+          server.id === selectedServerId
+            ? { ...server, jwtToken: undefined }
+            : server,
+        ),
+      }));
+      ircClient.requestExtJwt(selectedServerId, "*", "filehost");
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      const updated = useStore
+        .getState()
+        .servers.find((s) => s.id === selectedServerId);
+      jwtToken = updated?.jwtToken;
+    }
+    if (!jwtToken) {
+      console.error("Failed to obtain auth token for file upload");
+      return;
+    }
+
+    // Build the job list in one go so the progress strip appears
+    // immediately, before any network roundtrip.
+    const initialJobs: UploadJob[] = files.map((f) => ({
+      id: uuidv4(),
+      file: f,
+      loaded: 0,
+      total: f.size,
+      status: "pending",
+    }));
+    setUploadJobs((prev) => [...prev, ...initialJobs]);
+
+    const updateJob = (id: string, patch: Partial<UploadJob>) =>
+      setUploadJobs((prev) =>
+        prev.map((j) => (j.id === id ? { ...j, ...patch } : j)),
+      );
+
+    // Run all uploads in parallel; collect URLs in original input order.
+    const results = await Promise.all(
+      initialJobs.map(async (job) => {
+        // Cheap client-side validation -- saves a server round-trip
+        // and gives the user immediate feedback.
+        const validationError = validateFileAgainstInfo(job.file, info);
+        if (validationError) {
+          updateJob(job.id, {
+            status: "failed",
+            error: validationError,
+          });
+          return null;
+        }
+        const ac = new AbortController();
+        uploadAbortsRef.current.set(job.id, ac);
+        updateJob(job.id, { status: "uploading" });
+        try {
+          const url = await uploadFile(job.file, {
+            filehostUrl,
+            bearerToken: jwtToken as string,
+            signal: ac.signal,
+            onProgress: (loaded, total) => updateJob(job.id, { loaded, total }),
+          });
+          updateJob(job.id, {
+            status: "done",
+            loaded: job.file.size,
+            total: job.file.size,
+            url,
+          });
+          uploadAbortsRef.current.delete(job.id);
+          return url;
+        } catch (err) {
+          uploadAbortsRef.current.delete(job.id);
+          const msg = typeof err === "string" ? err : String(err);
+          updateJob(job.id, { status: "failed", error: msg });
+          return null;
+        }
+      }),
+    );
+
+    const urls = results.filter((u): u is string => !!u);
+    if (urls.length === 0) {
+      // All failed: leave the strip up so the user sees error reasons.
+      return;
+    }
+
+    // Send a single PRIVMSG carrying all successful URLs space-joined.
+    // Channels echo back; PMs need a local insert so the user sees
+    // their own message immediately.
+    const line = urls.join(" ");
+    ircClient.sendRaw(selectedServerId, `PRIVMSG ${target} :${line}`);
+    if (selectedPrivateChat && currentUser) {
+      const outgoing = {
+        id: uuidv4(),
+        content: line,
+        timestamp: new Date(),
+        userId: currentUser.username || currentUser.id,
+        channelId: selectedPrivateChat.id,
+        serverId: selectedServerId,
+        type: "message" as const,
+        reactions: [],
+        replyMessage: null,
+        mentioned: [],
+      };
+      useStore.getState().addMessage(outgoing);
+    }
+
+    // Clear the strip after a short pause so the user can see
+    // "done" before it disappears.
+    setTimeout(() => {
+      setUploadJobs((prev) =>
+        prev.filter((j) => !initialJobs.find((i) => i.id === j.id)),
+      );
+    }, 1500);
+  };
+
+  const cancelUploadJob = (id: string) => {
+    const ac = uploadAbortsRef.current.get(id);
+    if (ac) ac.abort();
+    setUploadJobs((prev) => prev.filter((j) => j.id !== id));
   };
 
   const handleGifSend = (gifUrl: string) => {
@@ -2022,29 +2175,44 @@ export const ChatArea: React.FC<{
                     <button
                       className="w-full text-left px-4 py-2 text-discord-text-normal hover:bg-discord-dark-300 rounded-lg flex items-center"
                       onClick={() => {
-                        // Handle image selection for preview
+                        // Multi-file picker: images, videos, audio.
+                        // The backend's allowlist is the source of
+                        // truth, but we hint accept= so the OS file
+                        // dialog filters sensibly.
                         const input = document.createElement("input");
                         input.type = "file";
-                        input.accept = "image/*";
+                        input.multiple = true;
+                        input.accept = "image/*,video/*,audio/*";
                         input.onchange = (e) => {
-                          const file = (e.target as HTMLInputElement)
-                            .files?.[0];
-                          if (file) {
-                            // Create preview URL
-                            const previewUrl = URL.createObjectURL(file);
+                          const files = Array.from(
+                            (e.target as HTMLInputElement).files ?? [],
+                          );
+                          if (files.length === 0) return;
+                          // For a single image, keep the legacy
+                          // confirm-then-upload preview UX so users
+                          // can see the picture before sending.
+                          if (
+                            files.length === 1 &&
+                            files[0].type.startsWith("image/")
+                          ) {
+                            const previewUrl = URL.createObjectURL(files[0]);
                             setImagePreview({
                               isOpen: true,
-                              file,
+                              file: files[0],
                               previewUrl,
                             });
+                            return;
                           }
+                          // Multi-file or non-image: go straight to
+                          // upload with the progress strip.
+                          handleFilesUpload(files);
                         };
                         input.click();
                         setShowPlusMenu(false);
                       }}
                     >
                       <FaPlus className="mr-2" />
-                      Upload Image
+                      Upload Files
                     </button>
                   )}
                   <button
@@ -2100,6 +2268,12 @@ export const ChatArea: React.FC<{
                   onClose={() => setIsEmojiSelectorOpen(false)}
                 />
               )}
+
+              {/* Multi-file upload progress strip, anchored above input */}
+              <UploadProgressOverlay
+                jobs={uploadJobs}
+                onCancel={cancelUploadJob}
+              />
 
               <AutocompleteDropdown
                 users={
@@ -2268,7 +2442,9 @@ export const ChatArea: React.FC<{
         }}
         onUpload={() => {
           if (imagePreview.file) {
-            handleImageUpload(imagePreview.file);
+            // Route through the new progress-aware path so single-file
+            // uploads also get the "uploading…" overlay.
+            handleFilesUpload([imagePreview.file]);
           }
           // Clean up preview URL
           if (imagePreview.previewUrl) {

--- a/src/components/ui/UploadProgressOverlay.tsx
+++ b/src/components/ui/UploadProgressOverlay.tsx
@@ -1,0 +1,98 @@
+// Progress strip rendered above the chat input while files are
+// uploading.  Each row shows the file name, a determinate bar driven
+// by XHR's upload-progress event, and a "done" / "failed" mark when
+// the upload settles.
+
+import type React from "react";
+import { FaCheck, FaFile, FaSpinner, FaTimes } from "react-icons/fa";
+
+export interface UploadJob {
+  id: string;
+  file: File;
+  loaded: number;
+  total: number;
+  status: "pending" | "uploading" | "done" | "failed";
+  error?: string;
+  url?: string;
+}
+
+interface Props {
+  jobs: UploadJob[];
+  onCancel?: (id: string) => void;
+}
+
+function fmtSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+export const UploadProgressOverlay: React.FC<Props> = ({ jobs, onCancel }) => {
+  if (jobs.length === 0) return null;
+  return (
+    <div className="absolute bottom-full left-0 right-0 mb-2 px-2 z-20">
+      <div className="bg-discord-dark-300 rounded-md shadow-lg border border-discord-dark-200 p-2 space-y-2">
+        <div className="text-xs text-discord-text-muted font-semibold uppercase tracking-wide px-1">
+          {jobs.length === 1
+            ? "Uploading 1 file"
+            : `Uploading ${jobs.length} files`}
+        </div>
+        {jobs.map((job) => {
+          const pct =
+            job.total > 0 ? Math.min(100, (job.loaded / job.total) * 100) : 0;
+          return (
+            <div key={job.id} className="text-sm">
+              <div className="flex items-center gap-2">
+                {job.status === "done" ? (
+                  <FaCheck className="text-discord-green flex-shrink-0" />
+                ) : job.status === "failed" ? (
+                  <FaTimes className="text-discord-red flex-shrink-0" />
+                ) : (
+                  <FaSpinner className="animate-spin text-discord-blue flex-shrink-0" />
+                )}
+                <FaFile className="text-discord-text-muted flex-shrink-0" />
+                <span className="truncate flex-1 text-white text-xs">
+                  {job.file.name}
+                </span>
+                <span className="text-xs text-discord-text-muted whitespace-nowrap">
+                  {job.status === "failed"
+                    ? "failed"
+                    : job.status === "done"
+                      ? "done"
+                      : `${fmtSize(job.loaded)} / ${fmtSize(job.total || job.file.size)}`}
+                </span>
+                {onCancel && job.status !== "done" && (
+                  <button
+                    type="button"
+                    onClick={() => onCancel(job.id)}
+                    className="text-discord-text-muted hover:text-white text-xs"
+                    aria-label="Cancel upload"
+                  >
+                    ✕
+                  </button>
+                )}
+              </div>
+              {job.status !== "done" && (
+                <div className="w-full mt-1 h-1.5 rounded bg-discord-dark-500 overflow-hidden">
+                  <div
+                    className={`h-full transition-[width] duration-150 ${
+                      job.status === "failed"
+                        ? "bg-discord-red"
+                        : "bg-discord-blue"
+                    }`}
+                    style={{ width: `${pct}%` }}
+                  />
+                </div>
+              )}
+              {job.error && (
+                <p className="text-xs text-discord-red mt-1">{job.error}</p>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default UploadProgressOverlay;

--- a/src/lib/mediaUpload.ts
+++ b/src/lib/mediaUpload.ts
@@ -1,0 +1,127 @@
+// XHR-based file uploader with progress reporting.
+//
+// fetch() doesn't expose upload-side progress events, which is why
+// we use XMLHttpRequest here instead -- the UI needs a real progress
+// bar while large videos are streaming up.
+//
+// uploadFile() resolves with the absolute saved URL on success and
+// rejects with a `string` describing the failure (string -- not Error
+// -- so the UI can show server text verbatim without unwrapping).
+
+export interface UploadInfo {
+  max_size: number;
+  allowed_extensions: string[];
+  scanning_enabled: boolean;
+}
+
+let cachedInfo: { url: string; info: UploadInfo } | null = null;
+
+/**
+ * Fetch the backend's upload policy.  Cached per filehost URL so
+ * mass-uploads don't hit the policy endpoint N times.  Returns null
+ * when the backend has no /upload/info (older deployment) -- caller
+ * falls back to "anything goes, see what sticks".
+ */
+export async function fetchUploadInfo(
+  filehostUrl: string,
+): Promise<UploadInfo | null> {
+  if (cachedInfo && cachedInfo.url === filehostUrl) return cachedInfo.info;
+  try {
+    const res = await fetch(`${filehostUrl}/upload/info`, {
+      headers: { Accept: "application/json" },
+    });
+    if (!res.ok) return null;
+    const info = (await res.json()) as UploadInfo;
+    cachedInfo = { url: filehostUrl, info };
+    return info;
+  } catch {
+    return null;
+  }
+}
+
+export interface UploadOptions {
+  filehostUrl: string;
+  bearerToken: string;
+  onProgress?: (loaded: number, total: number) => void;
+  signal?: AbortSignal;
+}
+
+/**
+ * Upload a single file via the backend's POST /upload endpoint.
+ * Resolves with the *absolute* URL of the saved file.
+ *
+ * The "file" form field is the new name; we pass it in addition to
+ * "image" for back-compat with older backend deployments that only
+ * recognise the legacy field name.
+ */
+export function uploadFile(file: File, opts: UploadOptions): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    const url = `${opts.filehostUrl.replace(/\/$/, "")}/upload`;
+
+    xhr.upload.addEventListener("progress", (e) => {
+      if (!e.lengthComputable) return;
+      opts.onProgress?.(e.loaded, e.total);
+    });
+
+    xhr.addEventListener("load", () => {
+      if (xhr.status < 200 || xhr.status >= 300) {
+        reject(xhr.responseText || `${xhr.status} ${xhr.statusText}`);
+        return;
+      }
+      try {
+        const body = JSON.parse(xhr.responseText) as { saved_url?: string };
+        if (!body.saved_url) {
+          reject("Backend response did not include saved_url");
+          return;
+        }
+        resolve(`${opts.filehostUrl.replace(/\/$/, "")}${body.saved_url}`);
+      } catch {
+        reject("Backend returned invalid JSON");
+      }
+    });
+    xhr.addEventListener("error", () => reject("Network error during upload"));
+    xhr.addEventListener("abort", () => reject("Upload cancelled"));
+
+    if (opts.signal) {
+      if (opts.signal.aborted) {
+        reject("Upload cancelled");
+        return;
+      }
+      opts.signal.addEventListener("abort", () => xhr.abort());
+    }
+
+    xhr.open("POST", url);
+    xhr.setRequestHeader("Authorization", `Bearer ${opts.bearerToken}`);
+
+    const form = new FormData();
+    // Send under both "file" (new) and "image" (legacy) so older
+    // backends keep working.
+    form.append("file", file);
+    form.append("image", file);
+    xhr.send(form);
+  });
+}
+
+/**
+ * Best-effort client-side validation against fetchUploadInfo() output.
+ * Returns null when the file is OK; otherwise a human-readable reason
+ * suitable for showing in the UI.
+ */
+export function validateFileAgainstInfo(
+  file: File,
+  info: UploadInfo | null,
+): string | null {
+  if (!info) return null;
+  if (info.max_size > 0 && file.size > info.max_size) {
+    return `File is too large (${(file.size / 1024 / 1024).toFixed(1)} MB > ${(info.max_size / 1024 / 1024).toFixed(0)} MB).`;
+  }
+  if (info.allowed_extensions.length > 0) {
+    const dot = file.name.lastIndexOf(".");
+    const ext = dot === -1 ? "" : file.name.slice(dot).toLowerCase();
+    if (!info.allowed_extensions.map((e) => e.toLowerCase()).includes(ext)) {
+      return `File type "${ext || "(none)"}" is not allowed.`;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
The "Upload Image" picker is now "Upload Files" -- it accepts multiple images, videos, and audio in one go, shows live per-file progress above the chat input, and on completion sends a single PRIVMSG containing every successful URL space-joined so the receiver sees one logical send instead of N separate messages.

  * lib/mediaUpload.ts: XHR-based uploader (fetch() doesn't expose upload-side progress events), with a `signal` for cancellation and a memo'd fetchUploadInfo() that pulls the backend's /upload/info policy once per filehost.  validateFileAgainstInfo() does cheap client-side allowlist / size checks before pushing bytes.  Form data is posted under both "file" (new) and "image" (legacy) so the new client works against older backend deployments too.

  * components/ui/UploadProgressOverlay.tsx: progress strip anchored above the input.  One row per file with a determinate bar fed by upload.onprogress, "done" / "failed" marks once each settles, and a per-row cancel button.

  * components/layout/ChatArea.tsx:
    - New `uploadJobs` state + `handleFilesUpload(files)` that runs uploads in parallel, surfaces progress, and on full success fires one `PRIVMSG <target> :<url1> <url2> <url3>`.  PMs get the local addMessage echo since channels echo back via echo-message.
    - The plus-menu "Upload Files" picker uses `accept="image/*,video/*,audio/*"` and `multiple`.  Single images still pass through the existing image-preview modal so the user can confirm before sending; everything else (or multi-select) goes straight to the upload path.
    - Image preview's "send" now routes through handleFilesUpload so single-image uploads also get the progress strip.
    - cancelUploadJob aborts the in-flight XHR.