### PR TITLE
chore(deps): bump openssl/rand/uuid/postcss for 8 dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6425,9 +6425,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",
@@ -7940,9 +7940,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2801,15 +2801,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.77"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -2833,9 +2832,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.113"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
@@ -3039,7 +3038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared 0.10.0",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3049,7 +3048,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3460,9 +3459,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3803,7 +3802,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",


### PR DESCRIPTION
## Summary

Lockfile-only bumps that close 8 of the 10 open Dependabot alerts on this repo. No source changes.

| Severity | Package | From → To | GHSA |
|---|---|---|---|
| 🔴 high | `openssl` | 0.10.77 → 0.10.79 | xp3w-r5p5-63rr |
| 🔴 high | `openssl` | (same bump) | 8c75-8mhr-p7r9 |
| 🔴 high | `openssl` | (same bump) | hppc-g8h3-xhp3 |
| 🔴 high | `openssl` | (same bump) | ghm9-cr32-g9qj |
| 🔴 high | `openssl` | (same bump) | pqf5-4pqq-29f5 |
| 🟡 low | `openssl` | (same bump) | xmgf-hq76-4vx2 |
| 🟠 medium | `uuid` | 11.0.x → 11.1.1 | w5hq-g745-h8pq |
| 🟠 medium | `postcss` | 8.5.x → 8.5.14 | qx2v-qp2m-jg93 |
| 🟡 low | `rand` (0.8) | 0.8.5 → 0.8.6 | cq8v-f236-94qc |

## Why one PR for everything

All bumps are SemVer-patch updates with no API breakage. Verified locally:
- `npm run build` — clean
- `cd src-tauri && cargo check` — clean

## Intentionally not in this PR

Two alerts can't be fixed with a lockfile bump:

- **`glib 0.18.5`** (medium, GHSA-wrw7-89jp-8q8g) — pinned by Tauri 2.10's GTK 0.18 bindings (atk → gtk → muda → tauri). Needs Tauri to ship a release with GTK 0.20 before we can move; tracked upstream.
- **`rand 0.7.3`** (low, GHSA-cq8v-f236-94qc) — build-time only, pulled in via `selectors → phf_codegen → phf_generator`. Not in any runtime code path; the runtime `rand` is the 0.8.6 covered above.

Both leftover alerts will be revisited when their upstreams move.

## Test plan

- [x] CI green
- [ ] Manual: desktop Tauri build still launches and connects
- [ ] Manual: `npm run android:release` produces a working APK
- [ ] Confirm Dependabot closes the 8 covered alerts after merge