### PR TITLE
fix(channel-settings): recognise ObbyIRCd in the UnrealIRCd-detection check

### DIFF
--- a/src/store/handlers/channels.ts
+++ b/src/store/handlers/channels.ts
@@ -209,10 +209,16 @@ export function registerChannelHandlers(store: StoreApi<AppState>): void {
   });
 
   ircClient.on("RPL_YOURHOST", ({ serverId, serverName, version }) => {
-    // Check if the server is running UnrealIRCd
-    const isUnrealIRCd = version.includes("UnrealIRCd");
+    // The `isUnrealIRCd` flag gates UI surfaces that lean on the
+    // UnrealIRCd module-driven chanmode set (the "Advanced" tab in
+    // ChannelSettingsModal, etc.). ObbyIRCd is a downstream fork that
+    // advertises its own name in 002 but inherits that chanmode set,
+    // so it satisfies the same UI gate. Any features ObbyIRCd adds on
+    // top (e.g. named-modes) are detected separately through their
+    // own caps and shouldn't be conflated with UnrealIRCd parity.
+    const isUnrealIRCd =
+      version.includes("UnrealIRCd") || version.includes("ObbyIRCd");
 
-    // Update the server with the UnrealIRCd information
     store.setState((state) => ({
       servers: state.servers.map((server) =>
         server.id === serverId ? { ...server, isUnrealIRCd } : server,


### PR DESCRIPTION
## Summary

The Channel Settings modal's "Advanced" tab is gated on
`server.isUnrealIRCd`, which gets set by string-matching the
RPL_YOURHOST (002) version. The check was an exact match for
\`UnrealIRCd\`. ObbyIRCd is a downstream fork that puts its own name
(\`ObbyIRCd-6.2.5-git\`) in 002, so the gate stayed false and channel
ops on ObbyIRCd networks lost access to the Advanced tab even though
the underlying chanmode surface is the same.

One-liner: include \`ObbyIRCd\` alongside \`UnrealIRCd\` in the
version-string match in [src/store/handlers/channels.ts](src/store/handlers/channels.ts).

The comment also calls out that ObbyIRCd-only features (e.g. named-modes,
which UnrealIRCd doesn't have) are detected via their own caps and should
NOT be conflated with the UnrealIRCd-parity flag.

## Test plan

- [ ] CI green
- [ ] Manual: connect to obby.t3ks.com (ObbyIRCd), open Channel Settings as
      a chanop, confirm "Advanced" tab shows alongside "Settings"/"General".
- [ ] Manual: connect to a vanilla UnrealIRCd, confirm Advanced still shows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced server type detection to recognize ObbyIRCd servers alongside UnrealIRCd, ensuring both server types now have access to appropriate UI features and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->