### PR TITLE
fix(standard-reply): show only the human-readable description

### DIFF
--- a/src/components/message/MessageItem.tsx
+++ b/src/components/message/MessageItem.tsx
@@ -520,6 +520,7 @@ export const MessageItem = memo((props: MessageItemProps) => {
             code={message.standardReplyCode}
             message={message.standardReplyMessage}
             target={message.standardReplyTarget}
+            context={message.standardReplyContext}
             timestamp={new Date(message.timestamp)}
             onIrcLinkClick={onIrcLinkClick}
           />

--- a/src/components/ui/StandardReplyNotification.tsx
+++ b/src/components/ui/StandardReplyNotification.tsx
@@ -13,85 +13,110 @@ interface StandardReplyNotificationProps {
   code: string;
   message: string;
   target?: string;
+  context?: string[];
   timestamp: Date;
   onIrcLinkClick?: (url: string) => void;
 }
 
+// IRCv3 standard-replies: only `<description>` is intended for human display.
+// `<command>` and `<code>` are computer-readable; we keep them on the row's
+// title attribute so power users can hover for the technical detail.
+// `<context>` strings are real-world identifiers (channel, nick, account)
+// referenced by the description — those are useful to the user, so we render
+// them as small chips alongside the message.
 export const StandardReplyNotification: React.FC<
   StandardReplyNotificationProps
-> = ({ type, command, code, message, target, timestamp, onIrcLinkClick }) => {
-  const formatTime = (date: Date) => {
-    return new Intl.DateTimeFormat("en-US", {
+> = ({
+  type,
+  command,
+  code,
+  message,
+  target,
+  context,
+  timestamp,
+  onIrcLinkClick,
+}) => {
+  const formatTime = (date: Date) =>
+    new Intl.DateTimeFormat("en-US", {
       hour: "2-digit",
       minute: "2-digit",
     }).format(date);
-  };
 
-  const getIcon = () => {
-    switch (type) {
-      case "FAIL":
-        return <FaTimesCircle className="text-red-500 flex-shrink-0" />;
-      case "WARN":
-        return (
-          <FaExclamationTriangle className="text-yellow-500 flex-shrink-0" />
-        );
-      case "NOTE":
-        return <FaInfoCircle className="text-blue-500 flex-shrink-0" />;
-      default:
-        return null;
-    }
-  };
+  const icon =
+    type === "FAIL" ? (
+      <FaTimesCircle className="text-red-500 flex-shrink-0" />
+    ) : type === "WARN" ? (
+      <FaExclamationTriangle className="text-yellow-500 flex-shrink-0" />
+    ) : (
+      <FaInfoCircle className="text-blue-500 flex-shrink-0" />
+    );
 
-  const getBackgroundColor = () => {
-    switch (type) {
-      case "FAIL":
-        return "bg-red-100 dark:bg-red-950/50 border-red-300 dark:border-red-700";
-      case "WARN":
-        return "bg-yellow-100 dark:bg-yellow-950/50 border-yellow-300 dark:border-yellow-700";
-      case "NOTE":
-        return "bg-blue-100 dark:bg-blue-950/50 border-blue-300 dark:border-blue-700";
-      default:
-        return "bg-gray-100 dark:bg-gray-950/50 border-gray-300 dark:border-gray-700";
-    }
-  };
+  const bg =
+    type === "FAIL"
+      ? "bg-red-100 dark:bg-red-950/50 border-red-300 dark:border-red-700"
+      : type === "WARN"
+        ? "bg-yellow-100 dark:bg-yellow-950/50 border-yellow-300 dark:border-yellow-700"
+        : "bg-blue-100 dark:bg-blue-950/50 border-blue-300 dark:border-blue-700";
 
-  const getTextColor = () => {
-    switch (type) {
-      case "FAIL":
-        return "text-red-800 dark:text-red-200";
-      case "WARN":
-        return "text-yellow-800 dark:text-yellow-200";
-      case "NOTE":
-        return "text-blue-800 dark:text-blue-200";
-      default:
-        return "text-gray-800 dark:text-gray-200";
-    }
-  };
+  const textColor =
+    type === "FAIL"
+      ? "text-red-800 dark:text-red-200"
+      : type === "WARN"
+        ? "text-yellow-800 dark:text-yellow-200"
+        : "text-blue-800 dark:text-blue-200";
 
-  const htmlContent = processMarkdownInText(
-    message,
-    true,
-    false,
-    `standard-reply-${command}-${code}-${timestamp.getTime()}`,
-  );
+  const chipBg =
+    type === "FAIL"
+      ? "bg-red-200/60 dark:bg-red-900/60"
+      : type === "WARN"
+        ? "bg-yellow-200/60 dark:bg-yellow-900/60"
+        : "bg-blue-200/60 dark:bg-blue-900/60";
+
+  // Resolve which context strings to show. Fall back to legacy `target` when
+  // `context` isn't provided (older callers).
+  const ctx = context && context.length > 0 ? context : target ? [target] : [];
+
+  // Hover tooltip carries the computer-readable bits for power users.
+  const hoverTitle = `${type} ${command} ${code}${ctx.length ? ` ${ctx.join(" ")}` : ""}`;
+
+  const description = message.trim();
+  const htmlContent = description
+    ? processMarkdownInText(
+        description,
+        true,
+        false,
+        `standard-reply-${command}-${code}-${timestamp.getTime()}`,
+      )
+    : "";
 
   return (
     <div
-      className={`mx-4 my-2 p-3 rounded-lg border ${getBackgroundColor()} shadow-sm`}
+      className={`mx-4 my-2 p-3 rounded-lg border ${bg} shadow-sm`}
+      title={hoverTitle}
     >
       <div className="flex items-start gap-3">
-        <div className="mt-0.5">{getIcon()}</div>
+        <div className="mt-0.5">{icon}</div>
         <div className="flex-1 min-w-0">
-          <div className={`text-sm font-medium ${getTextColor()} mb-1`}>
-            {type} {command} {code}
-            {target && <span className="font-normal"> • {target}</span>}
+          <div
+            className={`text-sm ${textColor} leading-relaxed break-words [overflow-wrap:anywhere]`}
+          >
+            {ctx.map((c) => (
+              <span
+                key={c}
+                className={`inline-block ${chipBg} ${textColor} text-xs font-mono rounded px-1.5 py-0.5 mr-2 align-middle`}
+              >
+                {c}
+              </span>
+            ))}
+            {htmlContent ? (
+              <EnhancedLinkWrapper onIrcLinkClick={onIrcLinkClick}>
+                {htmlContent}
+              </EnhancedLinkWrapper>
+            ) : (
+              <span className="opacity-60 italic">(no description)</span>
+            )}
           </div>
-          <div className={`text-sm ${getTextColor()} leading-relaxed`}>
-            <EnhancedLinkWrapper onIrcLinkClick={onIrcLinkClick}>
-              {htmlContent}
-            </EnhancedLinkWrapper>
-          </div>
-          <div className={`text-xs ${getTextColor()} opacity-70 mt-2`}>
+          <div className={`text-xs ${textColor} opacity-60 mt-2`}>
             {formatTime(timestamp)}
           </div>
         </div>

--- a/src/lib/irc/IRCClient.ts
+++ b/src/lib/irc/IRCClient.ts
@@ -158,24 +158,28 @@ export interface EventMap {
     command: string;
     code: string;
     target?: string;
+    context: string[];
     message: string;
   };
   WARN: EventWithTags & {
     command: string;
     code: string;
     target?: string;
+    context: string[];
     message: string;
   };
   NOTE: EventWithTags & {
     command: string;
     code: string;
     target?: string;
+    context: string[];
     message: string;
   };
   SUCCESS: EventWithTags & {
     command: string;
     code: string;
     target?: string;
+    context: string[];
     message: string;
   };
   REGISTER_SUCCESS: EventWithTags & {

--- a/src/lib/irc/handlers/auth.ts
+++ b/src/lib/irc/handlers/auth.ts
@@ -11,23 +11,46 @@ export function handleAuthenticate(
   ctx.triggerEvent("AUTHENTICATE", { serverId, param });
 }
 
+// IRCv3 standard-replies wire form:
+//   <prefix> {FAIL,WARN,NOTE,SUCCESS} <command> <code> [<context>...] :<description>
+// `description` is the human-readable text, always the trailing param.
+// `context` is zero or more identifiers (channel, nick, account) the
+// description refers to. `command` and `code` are computer-readable tokens.
+function splitStandardReply(
+  parv: string[],
+  trailing: string,
+): { command: string; code: string; context: string[]; message: string } {
+  const command = parv[0];
+  const code = parv[1];
+  // The parser pushes the trailing param onto parv as its last element when
+  // present. Pop it back off so context = the strings strictly between code
+  // and the description.
+  const hasTrailing = trailing.length > 0;
+  const ctxEnd = hasTrailing ? parv.length - 1 : parv.length;
+  const context = parv.slice(2, ctxEnd);
+  const message = hasTrailing ? trailing : parv.slice(2).join(" ");
+  return { command, code, context, message };
+}
+
 export function handleFail(
   ctx: IRCClientContext,
   serverId: string,
   _source: string,
   parv: string[],
   mtags: Record<string, string> | undefined,
+  trailing = "",
 ): void {
-  const cmd = parv[0];
-  const code = parv[1];
-  const target = parv[2] || undefined;
-  const message = parv.slice(3).join(" ").substring(1);
+  const { command, code, context, message } = splitStandardReply(
+    parv,
+    trailing,
+  );
   ctx.triggerEvent("FAIL", {
     serverId,
     mtags,
-    command: cmd,
+    command,
     code,
-    target,
+    target: context[0],
+    context,
     message,
   });
 }
@@ -38,17 +61,19 @@ export function handleWarn(
   _source: string,
   parv: string[],
   mtags: Record<string, string> | undefined,
+  trailing = "",
 ): void {
-  const cmd = parv[0];
-  const code = parv[1];
-  const target = parv[2] || undefined;
-  const message = parv.slice(3).join(" ").substring(1);
+  const { command, code, context, message } = splitStandardReply(
+    parv,
+    trailing,
+  );
   ctx.triggerEvent("WARN", {
     serverId,
     mtags,
-    command: cmd,
+    command,
     code,
-    target,
+    target: context[0],
+    context,
     message,
   });
 }
@@ -59,17 +84,19 @@ export function handleNote(
   _source: string,
   parv: string[],
   mtags: Record<string, string> | undefined,
+  trailing = "",
 ): void {
-  const cmd = parv[0];
-  const code = parv[1];
-  const target = parv[2] || undefined;
-  const message = parv.slice(3).join(" ").substring(1);
+  const { command, code, context, message } = splitStandardReply(
+    parv,
+    trailing,
+  );
   ctx.triggerEvent("NOTE", {
     serverId,
     mtags,
-    command: cmd,
+    command,
     code,
-    target,
+    target: context[0],
+    context,
     message,
   });
 }
@@ -80,17 +107,19 @@ export function handleSuccess(
   _source: string,
   parv: string[],
   mtags: Record<string, string> | undefined,
+  trailing = "",
 ): void {
-  const cmd = parv[0];
-  const code = parv[1];
-  const target = parv[2] || undefined;
-  const message = parv.slice(3).join(" ").substring(1);
+  const { command, code, context, message } = splitStandardReply(
+    parv,
+    trailing,
+  );
   ctx.triggerEvent("SUCCESS", {
     serverId,
     mtags,
-    command: cmd,
+    command,
     code,
-    target,
+    target: context[0],
+    context,
     message,
   });
 }
@@ -101,20 +130,16 @@ export function handleRegister(
   _source: string,
   parv: string[],
   mtags: Record<string, string> | undefined,
+  trailing = "",
 ): void {
   const subcommand = parv[0];
+  // REGISTER replies: REGISTER {SUCCESS,VERIFICATION_REQUIRED} <account> :<description>
+  // The description is the trailing param.
+  const account = parv[1];
+  const message = trailing || parv.slice(2).join(" ");
   if (subcommand === "SUCCESS") {
-    const account = parv[1];
-    const message = parv.slice(2).join(" ").substring(1);
-    ctx.triggerEvent("REGISTER_SUCCESS", {
-      serverId,
-      mtags,
-      account,
-      message,
-    });
+    ctx.triggerEvent("REGISTER_SUCCESS", { serverId, mtags, account, message });
   } else if (subcommand === "VERIFICATION_REQUIRED") {
-    const account = parv[1];
-    const message = parv.slice(2).join(" ").substring(1);
     ctx.triggerEvent("REGISTER_VERIFICATION_REQUIRED", {
       serverId,
       mtags,

--- a/src/lib/irc/handlers/index.ts
+++ b/src/lib/irc/handlers/index.ts
@@ -273,18 +273,18 @@ export const IRC_DISPATCH: Record<string, HandlerFn> = {
   AUTHENTICATE: (ctx, serverId, source, parv, mtags) =>
     handleAuthenticate(ctx, serverId, source, parv, mtags),
   // FAIL METADATA is a distinct protocol — route to the metadata handler
-  FAIL: (ctx, serverId, source, parv, mtags) =>
+  FAIL: (ctx, serverId, source, parv, mtags, trailing) =>
     parv[0] === "METADATA"
       ? handleMetadataFail(ctx, serverId, source, parv, mtags)
-      : handleFail(ctx, serverId, source, parv, mtags),
-  WARN: (ctx, serverId, source, parv, mtags) =>
-    handleWarn(ctx, serverId, source, parv, mtags),
-  NOTE: (ctx, serverId, source, parv, mtags) =>
-    handleNote(ctx, serverId, source, parv, mtags),
-  SUCCESS: (ctx, serverId, source, parv, mtags) =>
-    handleSuccess(ctx, serverId, source, parv, mtags),
-  REGISTER: (ctx, serverId, source, parv, mtags) =>
-    handleRegister(ctx, serverId, source, parv, mtags),
+      : handleFail(ctx, serverId, source, parv, mtags, trailing),
+  WARN: (ctx, serverId, source, parv, mtags, trailing) =>
+    handleWarn(ctx, serverId, source, parv, mtags, trailing),
+  NOTE: (ctx, serverId, source, parv, mtags, trailing) =>
+    handleNote(ctx, serverId, source, parv, mtags, trailing),
+  SUCCESS: (ctx, serverId, source, parv, mtags, trailing) =>
+    handleSuccess(ctx, serverId, source, parv, mtags, trailing),
+  REGISTER: (ctx, serverId, source, parv, mtags, trailing) =>
+    handleRegister(ctx, serverId, source, parv, mtags, trailing),
   VERIFY: (ctx, serverId, source, parv, mtags) =>
     handleVerify(ctx, serverId, source, parv, mtags),
   EXTJWT: (ctx, serverId, source, parv, mtags) =>

--- a/src/store/handlers/users.ts
+++ b/src/store/handlers/users.ts
@@ -861,21 +861,20 @@ export function registerUserHandlers(store: StoreApi<AppState>): void {
     });
   });
 
-  ircClient.on("WARN", ({ serverId, command, code, target, message }) => {
-    const state = store.getState();
-    const server = state.servers.find((s) => s.id === serverId);
-    if (server) {
-      let channel = server.channels.find(
-        (c) => c.id === getCurrentSelection(state).selectedChannelId,
-      );
-      if (!channel) {
-        channel = server.channels[0];
-      }
+  ircClient.on(
+    "WARN",
+    ({ serverId, command, code, target, context, message }) => {
+      const state = store.getState();
+      const server = state.servers.find((s) => s.id === serverId);
+      if (!server) return;
+      const selectedId = getCurrentSelection(state).selectedChannelId;
+      const channel =
+        server.channels.find((c) => c.id === selectedId) ?? server.channels[0];
       if (channel) {
         const notificationMessage: Message = {
           ...makeEventMessage(
             "standard-reply",
-            `WARN ${command} ${code}${target ? ` ${target}` : ""}: ${message}`,
+            message,
             "system",
             channel.id,
             serverId,
@@ -885,28 +884,39 @@ export function registerUserHandlers(store: StoreApi<AppState>): void {
           standardReplyCommand: command,
           standardReplyCode: code,
           standardReplyTarget: target,
+          standardReplyContext: context,
           standardReplyMessage: message,
         };
         appendMessage(store, serverId, channel.id, notificationMessage);
+      } else {
+        // No channels yet (pre-join WARN): surface as a global notification
+        // instead of dropping it.
+        state.addGlobalNotification({
+          type: "warn",
+          command,
+          code,
+          message,
+          target,
+          serverId,
+        });
       }
-    }
-  });
+    },
+  );
 
-  ircClient.on("NOTE", ({ serverId, command, code, target, message }) => {
-    const state = store.getState();
-    const server = state.servers.find((s) => s.id === serverId);
-    if (server) {
-      let channel = server.channels.find(
-        (c) => c.id === getCurrentSelection(state).selectedChannelId,
-      );
-      if (!channel) {
-        channel = server.channels[0];
-      }
+  ircClient.on(
+    "NOTE",
+    ({ serverId, command, code, target, context, message }) => {
+      const state = store.getState();
+      const server = state.servers.find((s) => s.id === serverId);
+      if (!server) return;
+      const selectedId = getCurrentSelection(state).selectedChannelId;
+      const channel =
+        server.channels.find((c) => c.id === selectedId) ?? server.channels[0];
       if (channel) {
         const notificationMessage: Message = {
           ...makeEventMessage(
             "standard-reply",
-            `NOTE ${command} ${code}${target ? ` ${target}` : ""}: ${message}`,
+            message,
             "system",
             channel.id,
             serverId,
@@ -916,12 +926,22 @@ export function registerUserHandlers(store: StoreApi<AppState>): void {
           standardReplyCommand: command,
           standardReplyCode: code,
           standardReplyTarget: target,
+          standardReplyContext: context,
           standardReplyMessage: message,
         };
         appendMessage(store, serverId, channel.id, notificationMessage);
+      } else {
+        state.addGlobalNotification({
+          type: "note",
+          command,
+          code,
+          message,
+          target,
+          serverId,
+        });
       }
-    }
-  });
+    },
+  );
 
   ircClient.on("RENAME", ({ serverId, oldName, newName, reason, user }) => {
     store.setState((state) => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -156,11 +156,13 @@ export interface Message {
   tags?: Record<string, string>;
   // Whisper fields (for draft/channel-context)
   whisperTarget?: string; // The recipient of a whisper
-  // Standard reply fields
+  // Standard reply fields. `command`, `code`, and `context` are
+  // computer-readable; only `message` is intended for human display.
   standardReplyType?: "FAIL" | "WARN" | "NOTE";
   standardReplyCommand?: string;
   standardReplyCode?: string;
   standardReplyTarget?: string;
+  standardReplyContext?: string[];
   standardReplyMessage?: string;
   // Batch-related fields for netsplit/netjoin
   batchId?: string;

--- a/tests/components/StandardReplyNotification.test.tsx
+++ b/tests/components/StandardReplyNotification.test.tsx
@@ -2,13 +2,11 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 import { StandardReplyNotification } from "../../src/components/ui/StandardReplyNotification";
 
-// Mock the IRC utilities
 vi.mock("../../src/lib/ircUtils", () => ({
   mircToHtml: vi.fn((text: string) => `<span>${text}</span>`),
   processMarkdownInText: vi.fn((text: string) => `<span>${text}</span>`),
 }));
 
-// Mock the LinkWrapper component
 vi.mock("../../src/components/ui/LinkWrapper", () => ({
   EnhancedLinkWrapper: ({
     children,
@@ -32,7 +30,7 @@ describe("StandardReplyNotification", () => {
     timestamp: new Date("2023-01-01T12:00:00Z"),
   };
 
-  test("renders FAIL notification with correct styling and icon", () => {
+  test("renders the human-readable description as the body", () => {
     render(
       <StandardReplyNotification
         {...baseProps}
@@ -40,89 +38,81 @@ describe("StandardReplyNotification", () => {
         onIrcLinkClick={mockOnIrcLinkClick}
       />,
     );
-
-    // Check that the notification is rendered
-    expect(
-      screen.getByText("FAIL AUTHENTICATE INVALID_CREDENTIALS"),
-    ).toBeInTheDocument();
-
-    // Check FAIL-specific styling (red colors) - find the main container by class
-    const mainContainer = document.querySelector(".bg-red-100");
-    expect(mainContainer).toHaveClass("bg-red-100", "border-red-300");
-    expect(mainContainer).toHaveClass(
-      "dark:bg-red-950/50",
-      "dark:border-red-700",
+    expect(screen.getByTestId("enhanced-link-wrapper")).toHaveTextContent(
+      "Authentication failed",
     );
-
-    // Check that the red icon is present (FaTimesCircle)
-    const iconContainer = screen.getByText(
-      "FAIL AUTHENTICATE INVALID_CREDENTIALS",
-    ).parentElement?.previousElementSibling;
-    expect(iconContainer).toBeInTheDocument();
   });
 
-  test("renders WARN notification with correct styling and icon", () => {
+  test("does NOT render command/code as visible text (computer-readable only)", () => {
     render(
       <StandardReplyNotification
         {...baseProps}
-        type="WARN"
+        type="FAIL"
         onIrcLinkClick={mockOnIrcLinkClick}
       />,
     );
-
-    expect(
-      screen.getByText("WARN AUTHENTICATE INVALID_CREDENTIALS"),
-    ).toBeInTheDocument();
-
-    // Check WARN-specific styling (yellow colors)
-    const mainContainer = document.querySelector(".bg-yellow-100");
-    expect(mainContainer).toHaveClass("bg-yellow-100", "border-yellow-300");
-    expect(mainContainer).toHaveClass(
-      "dark:bg-yellow-950/50",
-      "dark:border-yellow-700",
-    );
+    // Description text is what users see; command/code/type must not appear
+    // in any visible label.
+    expect(screen.queryByText(/AUTHENTICATE/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/INVALID_CREDENTIALS/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^FAIL$/)).not.toBeInTheDocument();
   });
 
-  test("renders NOTE notification with correct styling and icon", () => {
-    render(
-      <StandardReplyNotification
-        {...baseProps}
-        type="NOTE"
-        onIrcLinkClick={mockOnIrcLinkClick}
-      />,
-    );
-
-    expect(
-      screen.getByText("NOTE AUTHENTICATE INVALID_CREDENTIALS"),
-    ).toBeInTheDocument();
-
-    // Check NOTE-specific styling (blue colors)
-    const mainContainer = document.querySelector(".bg-blue-100");
-    expect(mainContainer).toHaveClass("bg-blue-100", "border-blue-300");
-    expect(mainContainer).toHaveClass(
-      "dark:bg-blue-950/50",
-      "dark:border-blue-700",
-    );
-  });
-
-  test("displays target when provided", () => {
-    render(
-      <StandardReplyNotification {...baseProps} type="FAIL" target="user123" />,
-    );
-
-    expect(screen.getByText(/FAIL/)).toBeInTheDocument();
-    expect(screen.getByText(/AUTHENTICATE/)).toBeInTheDocument();
-    expect(screen.getByText(/INVALID_CREDENTIALS/)).toBeInTheDocument();
-    expect(screen.getByText(/user123/)).toBeInTheDocument();
-  });
-
-  test("does not display target when not provided", () => {
+  test("FAIL applies red severity styling", () => {
     render(<StandardReplyNotification {...baseProps} type="FAIL" />);
+    const card = document.querySelector(".bg-red-100");
+    expect(card).toHaveClass("bg-red-100", "border-red-300");
+    expect(card).toHaveClass("dark:bg-red-950/50", "dark:border-red-700");
+  });
 
-    expect(
-      screen.getByText("FAIL AUTHENTICATE INVALID_CREDENTIALS"),
-    ).toBeInTheDocument();
-    expect(screen.queryByText("•")).not.toBeInTheDocument();
+  test("WARN applies yellow severity styling", () => {
+    render(<StandardReplyNotification {...baseProps} type="WARN" />);
+    const card = document.querySelector(".bg-yellow-100");
+    expect(card).toHaveClass("bg-yellow-100", "border-yellow-300");
+  });
+
+  test("NOTE applies blue severity styling", () => {
+    render(<StandardReplyNotification {...baseProps} type="NOTE" />);
+    const card = document.querySelector(".bg-blue-100");
+    expect(card).toHaveClass("bg-blue-100", "border-blue-300");
+  });
+
+  test("renders context strings as chips alongside the description", () => {
+    render(
+      <StandardReplyNotification
+        {...baseProps}
+        type="FAIL"
+        context={["#foo", "alice"]}
+      />,
+    );
+    expect(screen.getByText("#foo")).toBeInTheDocument();
+    expect(screen.getByText("alice")).toBeInTheDocument();
+  });
+
+  test("legacy `target` is rendered as a chip when no `context` is supplied", () => {
+    render(
+      <StandardReplyNotification {...baseProps} type="FAIL" target="#foo" />,
+    );
+    expect(screen.getByText("#foo")).toBeInTheDocument();
+  });
+
+  test("falls back to '(no description)' when message is empty", () => {
+    render(<StandardReplyNotification {...baseProps} type="FAIL" message="" />);
+    expect(screen.getByText("(no description)")).toBeInTheDocument();
+  });
+
+  test("exposes computer-readable info via the title attribute", () => {
+    render(
+      <StandardReplyNotification
+        {...baseProps}
+        type="FAIL"
+        context={["#foo"]}
+      />,
+    );
+    const card = document.querySelector("[title]") as HTMLElement | null;
+    expect(card?.getAttribute("title")).toBe(
+      "FAIL AUTHENTICATE INVALID_CREDENTIALS #foo",
+    );
   });
 
   test("displays formatted timestamp", () => {
@@ -134,36 +124,14 @@ describe("StandardReplyNotification", () => {
         timestamp={testDate}
       />,
     );
-
-    // Should display time in 12-hour format with 2 digits (in local timezone)
-    const expectedTime = new Intl.DateTimeFormat("en-US", {
+    const expected = new Intl.DateTimeFormat("en-US", {
       hour: "2-digit",
       minute: "2-digit",
     }).format(testDate);
-
-    expect(screen.getByText(expectedTime)).toBeInTheDocument();
+    expect(screen.getByText(expected)).toBeInTheDocument();
   });
 
-  test("renders message content through EnhancedLinkWrapper", () => {
-    render(
-      <StandardReplyNotification
-        {...baseProps}
-        type="WARN"
-        message="Warning: Invalid command"
-        onIrcLinkClick={mockOnIrcLinkClick}
-      />,
-    );
-
-    // Check that the message is wrapped in EnhancedLinkWrapper
-    const linkWrapper = screen.getByTestId("enhanced-link-wrapper");
-    expect(linkWrapper).toBeInTheDocument();
-    expect(linkWrapper).toHaveAttribute("data-onclick", "true");
-
-    // Check that mircToHtml was called and the result is displayed
-    expect(linkWrapper).toHaveTextContent("Warning: Invalid command");
-  });
-
-  test("handles onIrcLinkClick callback", () => {
+  test("passes onIrcLinkClick into EnhancedLinkWrapper", () => {
     render(
       <StandardReplyNotification
         {...baseProps}
@@ -171,37 +139,13 @@ describe("StandardReplyNotification", () => {
         onIrcLinkClick={mockOnIrcLinkClick}
       />,
     );
-
-    const linkWrapper = screen.getByTestId("enhanced-link-wrapper");
-    expect(linkWrapper).toHaveAttribute("data-onclick", "true");
+    const wrapper = screen.getByTestId("enhanced-link-wrapper");
+    expect(wrapper).toHaveAttribute("data-onclick", "true");
   });
 
   test("works without onIrcLinkClick callback", () => {
     render(<StandardReplyNotification {...baseProps} type="FAIL" />);
-
-    const linkWrapper = screen.getByTestId("enhanced-link-wrapper");
-    expect(linkWrapper).toHaveAttribute("data-onclick", "false");
-  });
-
-  test("applies correct text colors for each type", () => {
-    const { rerender } = render(
-      <StandardReplyNotification {...baseProps} type="FAIL" />,
-    );
-
-    // FAIL should have red text
-    let header = screen.getByText("FAIL AUTHENTICATE INVALID_CREDENTIALS");
-    expect(header).toHaveClass("text-red-800", "dark:text-red-200");
-
-    // Re-render with WARN
-    rerender(<StandardReplyNotification {...baseProps} type="WARN" />);
-
-    header = screen.getByText("WARN AUTHENTICATE INVALID_CREDENTIALS");
-    expect(header).toHaveClass("text-yellow-800", "dark:text-yellow-200");
-
-    // Re-render with NOTE
-    rerender(<StandardReplyNotification {...baseProps} type="NOTE" />);
-
-    header = screen.getByText("NOTE AUTHENTICATE INVALID_CREDENTIALS");
-    expect(header).toHaveClass("text-blue-800", "dark:text-blue-200");
+    const wrapper = screen.getByTestId("enhanced-link-wrapper");
+    expect(wrapper).toHaveAttribute("data-onclick", "false");
   });
 });

--- a/tests/lib/standardReplyHandlers.test.ts
+++ b/tests/lib/standardReplyHandlers.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  handleFail,
+  handleNote,
+  handleSuccess,
+  handleWarn,
+} from "../../src/lib/irc/handlers/auth";
+import type { IRCClientContext } from "../../src/lib/irc/IRCClientContext";
+
+function makeCtx() {
+  const triggered: { event: string; data: unknown }[] = [];
+  const ctx = {
+    triggerEvent: vi.fn((event: string, data: unknown) =>
+      triggered.push({ event, data }),
+    ),
+  } as unknown as IRCClientContext;
+  return { ctx, triggered };
+}
+
+// Mirror the parser's contract: trailing param is stripped of its leading
+// `:` and pushed onto parv as the last element when present.
+function parsedFromWire(line: string): {
+  parv: string[];
+  trailing: string;
+} {
+  // line is the body after the source prefix and the verb (e.g. "AUTHENTICATE BANNED #foo :Reason")
+  const colonIdx = line.indexOf(" :");
+  let mainPart = line;
+  let trailing = "";
+  if (colonIdx !== -1) {
+    trailing = line.substring(colonIdx + 2);
+    mainPart = line.substring(0, colonIdx);
+  }
+  const parv = mainPart.split(" ").filter((p) => p.length > 0);
+  if (trailing) parv.push(trailing);
+  return { parv, trailing };
+}
+
+describe("standard-replies handlers — parsing", () => {
+  test("FAIL preserves the description verbatim (no off-by-one)", () => {
+    const { ctx, triggered } = makeCtx();
+    const { parv, trailing } = parsedFromWire(
+      "JOIN BANNED #foo :You are banned from this channel",
+    );
+    handleFail(ctx, "srv", "server", parv, undefined, trailing);
+    expect(triggered).toHaveLength(1);
+    expect(triggered[0].event).toBe("FAIL");
+    const data = triggered[0].data as {
+      command: string;
+      code: string;
+      target?: string;
+      context: string[];
+      message: string;
+    };
+    expect(data.command).toBe("JOIN");
+    expect(data.code).toBe("BANNED");
+    expect(data.context).toEqual(["#foo"]);
+    expect(data.target).toBe("#foo");
+    expect(data.message).toBe("You are banned from this channel");
+  });
+
+  test("FAIL with no context: description is the trailing param, not parv[2]", () => {
+    const { ctx, triggered } = makeCtx();
+    const { parv, trailing } = parsedFromWire(
+      "ACC REG_INVALID_EMAIL :That email is not valid",
+    );
+    handleFail(ctx, "srv", "server", parv, undefined, trailing);
+    const data = triggered[0].data as {
+      context: string[];
+      target?: string;
+      message: string;
+    };
+    expect(data.context).toEqual([]);
+    expect(data.target).toBeUndefined();
+    expect(data.message).toBe("That email is not valid");
+  });
+
+  test("FAIL with multiple context strings", () => {
+    const { ctx, triggered } = makeCtx();
+    const { parv, trailing } = parsedFromWire(
+      "PRIVMSG CANNOT_SEND #foo alice :You are not in the channel",
+    );
+    handleFail(ctx, "srv", "server", parv, undefined, trailing);
+    const data = triggered[0].data as {
+      context: string[];
+      message: string;
+    };
+    expect(data.context).toEqual(["#foo", "alice"]);
+    expect(data.message).toBe("You are not in the channel");
+  });
+
+  test("WARN preserves description", () => {
+    const { ctx, triggered } = makeCtx();
+    const { parv, trailing } = parsedFromWire(
+      "PRIVMSG MESSAGE_TOO_LONG :Your message was truncated",
+    );
+    handleWarn(ctx, "srv", "server", parv, undefined, trailing);
+    expect((triggered[0].data as { message: string }).message).toBe(
+      "Your message was truncated",
+    );
+  });
+
+  test("NOTE preserves description", () => {
+    const { ctx, triggered } = makeCtx();
+    const { parv, trailing } = parsedFromWire(
+      "REGISTER ACCOUNT_HELD :Your account is held for review",
+    );
+    handleNote(ctx, "srv", "server", parv, undefined, trailing);
+    expect((triggered[0].data as { message: string }).message).toBe(
+      "Your account is held for review",
+    );
+  });
+
+  test("SUCCESS preserves description", () => {
+    const { ctx, triggered } = makeCtx();
+    const { parv, trailing } = parsedFromWire(
+      "REGISTER REGISTRATION_SUCCESS alice :You are now registered",
+    );
+    handleSuccess(ctx, "srv", "server", parv, undefined, trailing);
+    const data = triggered[0].data as {
+      context: string[];
+      message: string;
+    };
+    expect(data.context).toEqual(["alice"]);
+    expect(data.message).toBe("You are now registered");
+  });
+
+  test("description starting with a printable character is not corrupted", () => {
+    // Regression for the original `.substring(1)` bug which chopped the first
+    // character off every description.
+    const { ctx, triggered } = makeCtx();
+    const { parv, trailing } = parsedFromWire(
+      "JOIN BANNED #foo :Yikes, banned",
+    );
+    handleFail(ctx, "srv", "server", parv, undefined, trailing);
+    expect((triggered[0].data as { message: string }).message).toBe(
+      "Yikes, banned",
+    );
+  });
+});


### PR DESCRIPTION
The IRCv3 standard-replies spec is explicit that `<description>` is the end-user-facing text and `<command>`/`<code>` are computer-readable. The old UI inverted that — bolded `FAIL AUTHENTICATE SASL_FAIL` at the top and demoted the actual message — and the parser was also corrupting the description in two ways:

1. `parv.slice(N).join(" ").substring(1)` chopped the first character off every description (the parser already strips the leading `:`).
2. `parv[2]` was unconditionally treated as the context, so `FAIL CMD CODE :Description` (no context) was rendered as a chip with the description text and an empty body.

This refactors the FAIL/WARN/NOTE/SUCCESS/REGISTER handlers to use the `trailing` argument as the description and to slice context from `parv[2..n-1]`. The UI now renders only the description plus optional context chips for channels/nicks/accounts the description references. The technical command/code is still on the row's `title` for hover.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standard reply notifications now display context as chips alongside messages
  * Enhanced hover tooltips showing comprehensive message metadata

* **Bug Fixes**
  * Improved handling of empty descriptions with fallback text display

* **Tests**
  * Added test suite for standard reply message parsing and rendering

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ObsidianIRC/ObsidianIRC/pull/197)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->