### PR TITLE
fix(android): guard release signingConfig on missing storeFile

### DIFF
--- a/src-tauri/gen/android/app/build.gradle.kts
+++ b/src-tauri/gen/android/app/build.gradle.kts
@@ -61,7 +61,18 @@ android {
         }
         getByName("release") {
             isMinifyEnabled = true
-            signingConfig = signingConfigs.getByName("release")
+            // Only attach the release signingConfig when a real keystore was
+            // resolved above. On CI runners that ship without ~/.android/
+            // debug.keystore and don't write keystore.properties (the
+            // workflow signs the AAB/APK afterwards via apksigner), the
+            // signingConfig is half-initialised (storeFile == null) and
+            // packageUniversalRelease fails with `SigningConfig "release"
+            // is missing required property "storeFile"`. Leaving it unset
+            // produces an unsigned artifact, which the workflow then signs.
+            val releaseSign = signingConfigs.getByName("release")
+            if (releaseSign.storeFile != null) {
+                signingConfig = releaseSign
+            }
             proguardFiles(
                 *fileTree(".") { include("**/*.pro") }
                     .plus(getDefaultProguardFile("proguard-android-optimize.txt"))


### PR DESCRIPTION
## Summary

The Tauri Android jobs (\`publish-android\` + \`publish-android-google-play-internal\`) on main started failing after #198 with:

\`\`\`
> A failure occurred while executing com.android.build.gradle.tasks.PackageAndroidArtifact\$IncrementalSplitterRunnable
   > SigningConfig \"release\" is missing required property \"storeFile\".
\`\`\`

The new \`signingConfigs { release { ... } }\` block in [src-tauri/gen/android/app/build.gradle.kts](src-tauri/gen/android/app/build.gradle.kts) falls back to \`~/.android/debug.keystore\` when no \`keystore.properties\` is present. GitHub-hosted runners ship without \`~/.android/debug.keystore\`, so the release signingConfig ends up half-initialised (\`storeFile == null\`). The unconditional \`signingConfig = signingConfigs.getByName(\"release\")\` on the release build type then propagated the bad config into \`packageUniversalRelease\`.

The workflow signs the AAB/APK via \`apksigner\` *after* the gradle build, so the build itself doesn't need a configured signer — we just need gradle to produce an unsigned artifact.

This guards the assignment on \`releaseSign.storeFile != null\`. With a real keystore present (Play Store sign-in-place builds), the signing happens during gradle as before. Without one (CI), the artifact comes out unsigned and the workflow's apksigner step takes over.

## Test plan

- [ ] CI's \`Tauri Build and Publish > publish-android\` job reaches the apksigner step
- [ ] \`publish-android-google-play-internal\` likewise reaches its signing step
- [ ] Local \`npm run tauri android build\` still produces a signed APK when \`~/.android/debug.keystore\` exists (dev sideload path)