### PR TITLE
cap: restore no-implicit-names REQ (regression from a 2025 refactor)

### DIFF
--- a/src/lib/irc/IRCClient.ts
+++ b/src/lib/irc/IRCClient.ts
@@ -557,6 +557,14 @@ export class IRCClient implements IRCClientContext {
     "server-time",
     "echo-message",
     "userhost-in-names",
+    // We populate the member list from WHO/WHOX on JOIN (see
+    // store/handlers/messages.ts and store/index.ts), so we don't need
+    // -- and don't want -- the implicit RPL_NAMREPLY burst the server
+    // would otherwise emit. The ratified `no-implicit-names` cap tells
+    // the server to skip it; we also REQ the original draft name for
+    // back-compat with servers that haven't moved to the ratified form.
+    "no-implicit-names",
+    "draft/no-implicit-names",
     "draft/chathistory",
     "draft/event-playback",
     "draft/extended-isupport",


### PR DESCRIPTION
## Summary

The cap was originally REQ'd in [commit 25bc958](https://github.com/ObsidianIRC/ObsidianIRC/commit/25bc958) (May 2025) — *\"Use WHOX and draft/no-implicit-names instead of NAMES\"* — but was silently dropped on May 17 2025 in commit 3508ddf during a file-rewrite refactor (\"A little towards moving things into their own files\"). It's been missing from \`ourCaps\` ever since.

The client populates the member list from WHO/WHOX on JOIN ([src/store/handlers/messages.ts:1932](src/store/handlers/messages.ts#L1932), [src/store/index.ts:2400](src/store/index.ts#L2400)), so the server's implicit RPL_NAMREPLY burst is currently wasted bandwidth.

Request both the ratified \`no-implicit-names\` cap and the original \`draft/no-implicit-names\` name so older servers that haven't moved to the ratified form still suppress the burst.

## Test plan

- [ ] CAP REQ line now includes \`no-implicit-names\` and \`draft/no-implicit-names\`
- [ ] Joining a channel on a server that supports the cap no longer emits 353/366
- [ ] Member list still populates from WHO/WHOX
- [ ] Joining on a server that doesn't ACK the cap falls back to legacy NAMES behaviour

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the IRCv3 `no-implicit-names` capability, enabling improved compatibility with modern IRC servers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ObsidianIRC/ObsidianIRC/pull/200)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->