### PR TITLE
fix: capture CAP LS values so WebAuthn 2FA button enables on supported servers

### DIFF
--- a/src/components/ui/TwoFactorSettingsModal.tsx
+++ b/src/components/ui/TwoFactorSettingsModal.tsx
@@ -72,10 +72,22 @@ export const TwoFactorSettingsModal: React.FC<Props> = ({
   const [oauthBusy, setOauthBusy] = useState<string | null>(null);
   const [oauthError, setOauthError] = useState<string | null>(null);
 
-  const supportsWebAuthn =
-    server?.capabilities?.some(
-      (c) => c.startsWith("draft/account-2fa") && c.includes("webauthn"),
-    ) ?? false;
+  // The server advertises which 2FA factors it supports in the CAP LS
+  // value for draft/account-2fa (e.g. "totp,webauthn,oauth"). CAP ACK
+  // only echoes the cap name, so we read from `capabilityValues` --
+  // populated from CAP LS in src/store/handlers/auth.ts.
+  const supportsWebAuthn = (() => {
+    if (!server?.capabilities?.includes("draft/account-2fa")) return false;
+    const factors = server.capabilityValues?.["draft/account-2fa"];
+    // If the cap is acked but no value was seen in CAP LS, assume the
+    // server supports the standard factor set rather than silently
+    // disabling enrolment.
+    if (!factors) return true;
+    return factors
+      .split(",")
+      .map((f) => f.trim().toLowerCase())
+      .includes("webauthn");
+  })();
 
   const [enrollName, setEnrollName] = useState("");
   const [enrollCode, setEnrollCode] = useState("");

--- a/src/store/handlers/auth.ts
+++ b/src/store/handlers/auth.ts
@@ -490,6 +490,37 @@ export function registerAuthHandlers(store: StoreApi<AppState>): void {
 
   // Handle CAP LS to get informational capabilities like unrealircd.org/link-security
   ircClient.on("CAP LS", ({ serverId, cliCaps }) => {
+    // Capture per-cap value strings. CAP ACK only echoes the names so
+    // anything that wants to know "is webauthn one of the 2FA factors
+    // this server supports" needs to consult what was advertised in
+    // CAP LS. Drop the special unrealircd.org/link-security entry --
+    // it has its own typed field below.
+    const advertised: Record<string, string> = {};
+    for (const tok of cliCaps.split(/\s+/)) {
+      if (!tok) continue;
+      const eq = tok.indexOf("=");
+      if (eq <= 0) continue;
+      const name = tok.slice(0, eq);
+      const value = tok.slice(eq + 1);
+      if (name === "unrealircd.org/link-security") continue;
+      advertised[name] = value;
+    }
+    if (Object.keys(advertised).length) {
+      store.setState((state) => ({
+        servers: state.servers.map((server) =>
+          server.id === serverId
+            ? {
+                ...server,
+                capabilityValues: {
+                  ...(server.capabilityValues ?? {}),
+                  ...advertised,
+                },
+              }
+            : server,
+        ),
+      }));
+    }
+
     if (cliCaps.includes("unrealircd.org/link-security=")) {
       const match = cliCaps.match(/unrealircd\.org\/link-security=(\d+)/);
       if (match) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -37,6 +37,12 @@ export interface Server {
   awayMessage?: string; // Our away message on this server
   users: User[];
   capabilities?: string[];
+  // Per-cap value strings as advertised in CAP LS (e.g.
+  // "draft/account-2fa" -> "totp,webauthn,oauth", "sasl" ->
+  // "PLAIN,EXTERNAL"). CAP ACK only echoes names so the value list
+  // lives here and is consulted by UI that needs to know which
+  // sub-features the server actually supports.
+  capabilityValues?: Record<string, string>;
   metadata?: Record<string, { value: string | undefined; visibility: string }>;
   prefix?: string;
   chanmodes?: string; // CHANMODES ISUPPORT value defining mode groups A,B,C,D


### PR DESCRIPTION
## Summary

The \"Add biometric / security key\" button in [TwoFactorSettingsModal](src/components/ui/TwoFactorSettingsModal.tsx) was always grayed out, even on obbyircd which advertises \`draft/account-2fa=totp,webauthn,oauth\`. Tooltip read \"Server does not advertise WebAuthn support\".

**Root cause:** the button gated on grepping \`\"webauthn\"\` inside the \`server.capabilities[]\` entries, but that array is populated from **CAP ACK** ([store/handlers/auth.ts:557](src/store/handlers/auth.ts#L557)) — which only echoes cap **names**. The \`=value\` suffix lives only in **CAP LS** (\`:server CAP * LS :sasl draft/account-2fa=totp,webauthn,oauth ...\`), and the LS handler ignored every \`=value\` except \`unrealircd.org/link-security\`.

## Fix

- Add \`Server.capabilityValues: Record<string, string>\` to carry the CAP LS values.
- Parse every \`name=value\` pair out of CAP LS in the existing handler and merge it into \`capabilityValues\`.
- Modal now reads \`server.capabilityValues[\"draft/account-2fa\"]\`, splits on commas, and checks for \`\"webauthn\"\`. If the cap is acked but no value was advertised (some servers omit the factor list), assume the standard set rather than silently disabling.

## Test plan

- [ ] On a server advertising \`draft/account-2fa=totp,webauthn,oauth\`, the \"Add biometric / security key\" button is enabled.
- [ ] On a server advertising \`draft/account-2fa\` with no factor list, the button stays enabled (assumed standard set).
- [ ] On a server that does NOT advertise \`draft/account-2fa\` at all, the button is disabled with tooltip \"Server does not advertise WebAuthn support\".
- [ ] On a browser without \`navigator.credentials\` (insecure-context or non-WebAuthn build), the button is disabled with the browser tooltip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved server capability detection and storage for more accurate feature availability assessment.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ObsidianIRC/ObsidianIRC/pull/204)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->