### PR TITLE
fix: don't MARKREAD when the user has no account

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2021,10 +2021,14 @@ const useStore = create<AppState>((set, get) => ({
         }
 
         // draft/read-marker: tell the server how far we've read so
-        // our other sessions clear their unread state too.
+        // our other sessions clear their unread state too. The marker
+        // is keyed to the user's account on the server, so skip the
+        // request entirely when the user isn't logged in -- the
+        // server would just FAIL MARKREAD :Account required.
         if (
           channelName &&
-          server?.capabilities?.includes("draft/read-marker")
+          server?.capabilities?.includes("draft/read-marker") &&
+          ircClient.getCurrentUser(serverId)?.account
         ) {
           const ts = getLatestMessageTimestampIso(serverId, channelId);
           if (ts) ircClient.markreadSet(serverId, channelName, ts);
@@ -2229,8 +2233,14 @@ const useStore = create<AppState>((set, get) => ({
         // so the first time we open one ask for its stored marker
         // (so the unread badge can clear if another device already
         // read past it).  After that, push the latest timestamp like
-        // we do for channels.
-        if (pcUsername && server?.capabilities?.includes("draft/read-marker")) {
+        // we do for channels. The marker is keyed to the user's
+        // account on the server, so skip when the user isn't logged
+        // in (server would FAIL MARKREAD :Account required).
+        if (
+          pcUsername &&
+          server?.capabilities?.includes("draft/read-marker") &&
+          ircClient.getCurrentUser(serverId)?.account
+        ) {
           if (!pc?.readMarkerFetched) {
             ircClient.markreadGet(serverId, pcUsername);
           }


### PR DESCRIPTION
## Summary

Users without a logged-in account were seeing FAIL replies like \"Account required for MARKREAD\" when selecting channels / opening PMs. The read-marker is keyed to the user's account on the server, so without an account there's nothing to persist anyway.

The two MARKREAD send sites in [src/store/index.ts:2025](src/store/index.ts#L2025) (channel select) and [src/store/index.ts:2233](src/store/index.ts#L2233) (PM open) only gated on the \`draft/read-marker\` cap being acked. The cap is negotiated up-front, well before authentication completes (or never, for users who don't log in at all), so we were firing MARKREAD on every channel/PM activation regardless of account status.

## Fix

Also require \`ircClient.getCurrentUser(serverId)?.account\` to be set before sending MARKREAD. The account field is populated by account-tag / extended-join / WHO once SASL completes; for unauthenticated users it stays empty.

## Test plan

- [ ] Connect without SASL → switching channels / opening PMs does not fire MARKREAD; no FAIL replies.
- [ ] Connect with SASL → MARKREAD still fires on channel/PM selection and the read-marker syncs across sessions.