### PR TITLE
voice: wait for JOIN echo before sending SFU "join" signal

### DIFF
--- a/src/lib/voice.ts
+++ b/src/lib/voice.ts
@@ -274,6 +274,11 @@ export class VoiceClient {
   private statsTimer?: ReturnType<typeof setInterval>;
   private state: VoiceState = { phase: "idle" };
   private tagmsgUnsub?: () => void;
+  // Pending JOIN-echo wait state. Both must be cleared on teardown to
+  // stop a torn-down session from firing the SFU "join" or leaking a
+  // stale JOIN hook into the next session.
+  private joinEchoUnsub?: () => void;
+  private joinEchoTimeout?: ReturnType<typeof setTimeout>;
   private speakingTimer?: ReturnType<typeof setInterval>;
   private vadAudioCtx?: AudioContext;
   private isSpeakingNow = false;
@@ -351,19 +356,32 @@ export class VoiceClient {
       this.sendSignal({ type: "join", channel });
     };
     let signaled = false;
+    const clearJoinEchoWait = () => {
+      if (this.joinEchoUnsub) {
+        this.joinEchoUnsub();
+        this.joinEchoUnsub = undefined;
+      }
+      if (this.joinEchoTimeout) {
+        clearTimeout(this.joinEchoTimeout);
+        this.joinEchoTimeout = undefined;
+      }
+    };
     const joinHandler = (p: { username: string; channelName: string }) => {
       if (signaled) return;
-      if (p.username !== selfNick) return;
+      // IRC nicks are case-insensitive per RFC 1459 -- the server may
+      // echo a casing different from this.opts.selfNick.
+      if (p.username.toLowerCase() !== selfNick.toLowerCase()) return;
       if (p.channelName.toLowerCase() !== channel.toLowerCase()) return;
       signaled = true;
-      ircClient.deleteHook("JOIN", joinHandler);
+      clearJoinEchoWait();
       sendJoinSignal();
     };
     ircClient.on("JOIN", joinHandler);
-    setTimeout(() => {
+    this.joinEchoUnsub = () => ircClient.deleteHook("JOIN", joinHandler);
+    this.joinEchoTimeout = setTimeout(() => {
       if (signaled) return;
       signaled = true;
-      ircClient.deleteHook("JOIN", joinHandler);
+      clearJoinEchoWait();
       sendJoinSignal();
     }, 2000);
 
@@ -1255,6 +1273,14 @@ export class VoiceClient {
     if (this.tagmsgUnsub) {
       this.tagmsgUnsub();
       this.tagmsgUnsub = undefined;
+    }
+    if (this.joinEchoUnsub) {
+      this.joinEchoUnsub();
+      this.joinEchoUnsub = undefined;
+    }
+    if (this.joinEchoTimeout) {
+      clearTimeout(this.joinEchoTimeout);
+      this.joinEchoTimeout = undefined;
     }
     for (const sink of this.memberAudioSinks.values()) {
       sink.srcObject = null;

--- a/src/lib/voice.ts
+++ b/src/lib/voice.ts
@@ -334,11 +334,40 @@ export class VoiceClient {
     ircClient.on("TAGMSG", handler);
     this.tagmsgUnsub = () => ircClient.deleteHook("TAGMSG", handler);
 
-    // Step 1: appear in the IRC channel.
-    ircClient.sendRaw(this.opts.serverId, `JOIN ${this.opts.channel}`);
+    // Step 1: appear in the IRC channel, then wait for the server's
+    // own echoed JOIN before sending the SFU "join" TAGMSG. Without
+    // the wait the TAGMSG can race the JOIN on the server side: the
+    // session that's actually a member of the channel may not be the
+    // same session that just sent the TAGMSG (multi-session
+    // persistence migrations), and the channel's +n mode then bounces
+    // the signaling line with ERR_CANNOTSENDTOCHAN, leaving the SFU
+    // never told the user joined. Waiting for the echo means we only
+    // signal once the server confirmed our membership on this
+    // connection. Safety timeout sends anyway after 2 s so an old
+    // server that doesn't echo cleanly doesn't strand the call.
+    const channel = this.opts.channel;
+    const selfNick = this.opts.selfNick;
+    const sendJoinSignal = () => {
+      this.sendSignal({ type: "join", channel });
+    };
+    let signaled = false;
+    const joinHandler = (p: { username: string; channelName: string }) => {
+      if (signaled) return;
+      if (p.username !== selfNick) return;
+      if (p.channelName.toLowerCase() !== channel.toLowerCase()) return;
+      signaled = true;
+      ircClient.deleteHook("JOIN", joinHandler);
+      sendJoinSignal();
+    };
+    ircClient.on("JOIN", joinHandler);
+    setTimeout(() => {
+      if (signaled) return;
+      signaled = true;
+      ircClient.deleteHook("JOIN", joinHandler);
+      sendJoinSignal();
+    }, 2000);
 
-    // Step 2: signal join to the SFU.
-    this.sendSignal({ type: "join", channel: this.opts.channel });
+    ircClient.sendRaw(this.opts.serverId, `JOIN ${this.opts.channel}`);
   }
 
   leave(): void {


### PR DESCRIPTION
## Symptom

Reported on prod:

\`\`\`
C: JOIN \$lol
C: @+obsidianirc/rtc={\"type\":\"join\",\"channel\":\"\$lol\"} TAGMSG \$lol
S: :obby.t3ks.com 404 Valware \$lol :No external channel messages (\$lol)
\`\`\`

Server logs show \`User Valware joined \$lol\` succeeded, yet the TAGMSG that followed immediately was rejected with +n.

## Cause

[src/lib/voice.ts:338](src/lib/voice.ts#L338) sent the SFU \`join\` TAGMSG right after \`JOIN\`, with no wait. On multi-session connections (obbyircd persistence) the session that ends up canonical can differ from the session that issued the TAGMSG — the chan-membership update lands on one socket while the TAGMSG sails out of another, and +n bounces it.

## Fix

Subscribe to the IRC \`JOIN\` event for our own nick + target channel, send the TAGMSG only after the echo arrives. 2 s safety timeout sends anyway so a server that doesn't echo cleanly doesn't strand the call.

## Test plan

- [x] Click a \`\$\` or \`^\` channel — observe \`JOIN \$chan\` on the wire, then the rtc TAGMSG only after the server's \`:nick JOIN \$chan\` echo.
- [x] No more \`404 ... :No external channel messages\` for the rtc TAGMSG.
- [x] Second tab joining the same channel works (multi-session).
- [ ] Call still establishes when the server's JOIN echo is delayed (\\>2s simulated): TAGMSG fires after the timeout fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved voice channel joining reliability through enhanced connection synchronization before audio stream establishment.
  * Added a safety timeout mechanism to prevent prolonged delays if connection confirmation is not received.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ObsidianIRC/ObsidianIRC/pull/209)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->