### PR TITLE
fix(metadata): lazy-load per-user metadata to stop recvq flood (#116)

### DIFF
--- a/src/components/layout/MemberList.tsx
+++ b/src/components/layout/MemberList.tsx
@@ -1,6 +1,6 @@
 import { Trans, useLingui } from "@lingui/react/macro";
 import type React from "react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { FaCheckCircle, FaChevronLeft } from "react-icons/fa";
 import { useMediaQuery } from "../../hooks/useMediaQuery";
 import ircClient from "../../lib/ircClient";
@@ -100,7 +100,17 @@ const UserItem: React.FC<{
     channelId: string,
     avatarElement?: Element | null,
   ) => void;
-}> = ({ user, serverId, channelId, currentUser, onContextMenu }) => {
+  // Lazy-metadata: parent observes each item with an IntersectionObserver
+  // so we only METADATA LIST users the user actually scrolls to.
+  registerObserverItem?: (username: string, el: Element | null) => void;
+}> = ({
+  user,
+  serverId,
+  channelId,
+  currentUser,
+  onContextMenu,
+  registerObserverItem,
+}) => {
   const { t } = useLingui();
   const [avatarLoadFailed, setAvatarLoadFailed] = useState(false);
 
@@ -165,6 +175,8 @@ const UserItem: React.FC<{
 
   return (
     <div
+      ref={(el) => registerObserverItem?.(user.username, el)}
+      data-username={user.username}
       className="flex items-center gap-3 py-2 px-3 mx-2 mb-1 rounded cursor-pointer bg-discord-dark-400/30 hover:bg-discord-dark-400/50 transition-colors"
       onClick={(e) => {
         const avatarElement = e.currentTarget.querySelector(".w-10.h-10");
@@ -337,6 +349,83 @@ export const MemberList: React.FC = () => {
     selectedPrivateChatId: null,
   };
   const { selectedChannelId } = currentSelection;
+
+  // Lazy-metadata wiring. We track which nicks the scroller has actually
+  // landed on (via IntersectionObserver), wait for scrolling to come to
+  // rest (SCROLL_IDLE_MS), then ask the store to METADATA LIST any
+  // currently-visible nick we haven't already requested. The store
+  // dedups + the lazy queue drips so a burst of visible nicks doesn't
+  // hammer the server (issue #116).
+  const SCROLL_IDLE_MS = 250;
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const itemsRef = useRef(new Map<string, Element>());
+  const visibleUsernamesRef = useRef(new Set<string>());
+  const flushTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+
+  const flushVisible = useCallback(() => {
+    if (!selectedServerId) return;
+    const list = useStore.getState().metadataList;
+    for (const username of visibleUsernamesRef.current) {
+      list(selectedServerId, username);
+    }
+  }, [selectedServerId]);
+
+  const scheduleFlush = useCallback(() => {
+    if (flushTimerRef.current) clearTimeout(flushTimerRef.current);
+    flushTimerRef.current = setTimeout(flushVisible, SCROLL_IDLE_MS);
+  }, [flushVisible]);
+
+  const registerObserverItem = useCallback(
+    (username: string, el: Element | null) => {
+      if (!el) {
+        const old = itemsRef.current.get(username);
+        if (old && observerRef.current) observerRef.current.unobserve(old);
+        itemsRef.current.delete(username);
+        visibleUsernamesRef.current.delete(username);
+        return;
+      }
+      itemsRef.current.set(username, el);
+      observerRef.current?.observe(el);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const root = scrollContainerRef.current;
+    if (!root) return;
+    const obs = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          const username = (entry.target as HTMLElement).dataset.username;
+          if (!username) continue;
+          if (entry.isIntersecting) visibleUsernamesRef.current.add(username);
+          else visibleUsernamesRef.current.delete(username);
+        }
+        scheduleFlush();
+      },
+      { root, threshold: 0 },
+    );
+    observerRef.current = obs;
+    for (const el of itemsRef.current.values()) obs.observe(el);
+    const onScroll = () => scheduleFlush();
+    root.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      obs.disconnect();
+      observerRef.current = null;
+      root.removeEventListener("scroll", onScroll);
+      if (flushTimerRef.current) clearTimeout(flushTimerRef.current);
+    };
+  }, [scheduleFlush]);
+
+  // Channel changes remount items so the observer naturally re-binds via
+  // the callback ref; reset the visibility set so we don't carry over
+  // a stale "X was visible" from the previous channel.
+  useEffect(() => {
+    visibleUsernamesRef.current.clear();
+  }, []);
 
   const [userContextMenu, setUserContextMenu] = useState<{
     isOpen: boolean;
@@ -533,7 +622,7 @@ export const MemberList: React.FC = () => {
 
   const isMobileView = useMediaQuery();
   return (
-    <div className="px-1 py-3 h-full overflow-y-auto">
+    <div ref={scrollContainerRef} className="px-1 py-3 h-full overflow-y-auto">
       {isMobileView && (
         <button
           onClick={() => toggleMemberList(false)}
@@ -553,6 +642,7 @@ export const MemberList: React.FC = () => {
           channelId={selectedChannelId || ""}
           currentUser={currentUser}
           onContextMenu={handleUsernameClick}
+          registerObserverItem={registerObserverItem}
         />
       ))}
 

--- a/src/components/layout/MemberList.tsx
+++ b/src/components/layout/MemberList.tsx
@@ -100,16 +100,16 @@ const UserItem: React.FC<{
     channelId: string,
     avatarElement?: Element | null,
   ) => void;
-  // Lazy-metadata: parent observes each item with an IntersectionObserver
-  // so we only METADATA LIST users the user actually scrolls to.
-  registerObserverItem?: (username: string, el: Element | null) => void;
+  // The very first member item gets refMeasure(el) so the parent can
+  // sample offsetHeight for its scrollTop-based visibility math.
+  refMeasure?: (el: HTMLDivElement | null) => void;
 }> = ({
   user,
   serverId,
   channelId,
   currentUser,
   onContextMenu,
-  registerObserverItem,
+  refMeasure,
 }) => {
   const { t } = useLingui();
   const [avatarLoadFailed, setAvatarLoadFailed] = useState(false);
@@ -175,7 +175,7 @@ const UserItem: React.FC<{
 
   return (
     <div
-      ref={(el) => registerObserverItem?.(user.username, el)}
+      ref={refMeasure}
       data-username={user.username}
       className="flex items-center gap-3 py-2 px-3 mx-2 mb-1 rounded cursor-pointer bg-discord-dark-400/30 hover:bg-discord-dark-400/50 transition-colors"
       onClick={(e) => {
@@ -350,26 +350,53 @@ export const MemberList: React.FC = () => {
   };
   const { selectedChannelId } = currentSelection;
 
-  // Lazy-metadata wiring. We track which nicks the scroller has actually
-  // landed on (via IntersectionObserver), wait for scrolling to come to
-  // rest (SCROLL_IDLE_MS), then ask the store to METADATA LIST any
-  // currently-visible nick we haven't already requested. The store
-  // dedups + the lazy queue drips so a burst of visible nicks doesn't
-  // hammer the server (issue #116).
+  // Lazy-metadata wiring: on scroll-stop, compute which slice of
+  // sortedUsers is currently inside the scroll container's viewport
+  // (from scrollTop + clientHeight, not IntersectionObserver -- IO was
+  // misreporting on this layout, fetching members from the bottom of
+  // the list upward instead of from the visible top). Then dispatch
+  // METADATA LIST for that slice in top-to-bottom order. The store
+  // dedups and the lazy queue drips so a burst of new visible nicks
+  // can't hammer the server (issue #116).
   const SCROLL_IDLE_MS = 250;
+  // Cap per scroll-stop so a sudden landing on a wall of unfetched
+  // nicks doesn't queue hundreds at once.
+  const MAX_FETCH_PER_FLUSH = 30;
+  // Render a couple of off-screen rows ahead/behind so the avatars are
+  // ready by the time the user scrolls to them.
+  const VISIBILITY_OVERSCAN = 5;
   const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const observerRef = useRef<IntersectionObserver | null>(null);
-  const itemsRef = useRef(new Map<string, Element>());
-  const visibleUsernamesRef = useRef(new Set<string>());
+  const firstItemRef = useRef<HTMLDivElement | null>(null);
+  // Mirror of the current sorted member list so flushVisible can map an
+  // index back to a nick without going through React state.
+  const sortedOrderRef = useRef<string[]>([]);
   const flushTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
 
   const flushVisible = useCallback(() => {
     if (!selectedServerId) return;
+    const root = scrollContainerRef.current;
+    const order = sortedOrderRef.current;
+    if (!root || order.length === 0) return;
+    const itemHeight = firstItemRef.current?.offsetHeight || 56;
+    const start = Math.max(
+      0,
+      Math.floor(root.scrollTop / itemHeight) - VISIBILITY_OVERSCAN,
+    );
+    const end = Math.min(
+      order.length,
+      Math.ceil((root.scrollTop + root.clientHeight) / itemHeight) +
+        VISIBILITY_OVERSCAN,
+    );
+    if (end <= start) return;
     const list = useStore.getState().metadataList;
-    for (const username of visibleUsernamesRef.current) {
+    let queued = 0;
+    for (let i = start; i < end && queued < MAX_FETCH_PER_FLUSH; i++) {
+      const username = order[i];
+      if (!username) continue;
       list(selectedServerId, username);
+      queued++;
     }
   }, [selectedServerId]);
 
@@ -378,54 +405,22 @@ export const MemberList: React.FC = () => {
     flushTimerRef.current = setTimeout(flushVisible, SCROLL_IDLE_MS);
   }, [flushVisible]);
 
-  const registerObserverItem = useCallback(
-    (username: string, el: Element | null) => {
-      if (!el) {
-        const old = itemsRef.current.get(username);
-        if (old && observerRef.current) observerRef.current.unobserve(old);
-        itemsRef.current.delete(username);
-        visibleUsernamesRef.current.delete(username);
-        return;
-      }
-      itemsRef.current.set(username, el);
-      observerRef.current?.observe(el);
-    },
-    [],
-  );
-
   useEffect(() => {
     const root = scrollContainerRef.current;
     if (!root) return;
-    const obs = new IntersectionObserver(
-      (entries) => {
-        for (const entry of entries) {
-          const username = (entry.target as HTMLElement).dataset.username;
-          if (!username) continue;
-          if (entry.isIntersecting) visibleUsernamesRef.current.add(username);
-          else visibleUsernamesRef.current.delete(username);
-        }
-        scheduleFlush();
-      },
-      { root, threshold: 0 },
-    );
-    observerRef.current = obs;
-    for (const el of itemsRef.current.values()) obs.observe(el);
     const onScroll = () => scheduleFlush();
     root.addEventListener("scroll", onScroll, { passive: true });
+    // Initial sweep once layout has settled so the topmost visible
+    // chunk gets fetched without requiring user interaction.
+    scheduleFlush();
     return () => {
-      obs.disconnect();
-      observerRef.current = null;
       root.removeEventListener("scroll", onScroll);
       if (flushTimerRef.current) clearTimeout(flushTimerRef.current);
     };
   }, [scheduleFlush]);
 
-  // Channel changes remount items so the observer naturally re-binds via
-  // the callback ref; reset the visibility set so we don't carry over
-  // a stale "X was visible" from the previous channel.
-  useEffect(() => {
-    visibleUsernamesRef.current.clear();
-  }, []);
+  // (Initial-sweep re-arm useEffect moved below sortedUsers declaration
+  //  -- see "memberlist sweep" comment further down.)
 
   const [userContextMenu, setUserContextMenu] = useState<{
     isOpen: boolean;
@@ -495,6 +490,22 @@ export const MemberList: React.FC = () => {
     }
     return a.username.localeCompare(b.username);
   });
+  // Keep an order ref so flushVisible (a stable useCallback) can find
+  // each visible nick's on-screen position without going back into the
+  // store. Updated synchronously during render -- read in callbacks
+  // that fire after.
+  sortedOrderRef.current = sortedUsers?.map((u) => u.username) ?? [];
+
+  // memberlist sweep: re-arm flushVisible whenever (a) the channel
+  // changes or (b) the user count changes -- in particular when it
+  // jumps from 0 to N as the batched WHO reply lands. Without this the
+  // very first flushVisible runs while sortedOrderRef is still empty
+  // (returns early, no fetch) and we then wait for a scroll event
+  // before any metadata is requested.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scheduleFlush identity is stable
+  useEffect(() => {
+    scheduleFlush();
+  }, [selectedChannelId, sortedUsers?.length]);
 
   const handleUsernameClick = (
     e: React.MouseEvent,
@@ -634,7 +645,7 @@ export const MemberList: React.FC = () => {
       <h3 className="text-xs font-semibold text-discord-channels-default uppercase mb-2 px-2">
         <Trans>Members — {sortedUsers?.length || 0}</Trans>
       </h3>
-      {sortedUsers?.map((user) => (
+      {sortedUsers?.map((user, idx) => (
         <UserItem
           key={user.id}
           user={user}
@@ -642,7 +653,13 @@ export const MemberList: React.FC = () => {
           channelId={selectedChannelId || ""}
           currentUser={currentUser}
           onContextMenu={handleUsernameClick}
-          registerObserverItem={registerObserverItem}
+          refMeasure={
+            idx === 0
+              ? (el) => {
+                  firstItemRef.current = el;
+                }
+              : undefined
+          }
         />
       ))}
 

--- a/src/store/handlers/channels.ts
+++ b/src/store/handlers/channels.ts
@@ -4,7 +4,7 @@ import type { StoreApi } from "zustand";
 import ircClient from "../../lib/ircClient";
 import { isChannelTarget } from "../../lib/ircUtils";
 import type { Message } from "../../types";
-import { resolveUserMetadata, serverSupportsMetadata } from "../helpers";
+import { resolveUserMetadata } from "../helpers";
 import type { AppState } from "../index";
 import * as storage from "../localStorage";
 
@@ -406,24 +406,11 @@ export function registerChannelHandlers(store: StoreApi<AppState>): void {
         return server;
       });
 
-      // Request metadata for users who don't have it yet
-      if (serverSupportsMetadata(state, serverId)) {
-        const serverData = updatedServers.find((s) => s.id === serverId);
-        const channelData = serverData?.channels.find(
-          (c) => c.name.toLowerCase() === channelName.toLowerCase(),
-        );
-
-        if (channelData) {
-          // Request metadata for users who don't have it
-          channelData.users.forEach((user) => {
-            const hasMetadata =
-              user.metadata && Object.keys(user.metadata).length > 0;
-            if (!hasMetadata) {
-              store.getState().metadataList(serverId, user.username);
-            }
-          });
-        }
-      }
+      // Per-user metadata is fetched lazily now (MemberList scroll-stop
+      // visibility + CHANMSG/USERMSG speak triggers). On a 200-user
+      // channel this loop used to fire 200 METADATA LIST commands in a
+      // tight burst on JOIN, tripping recvq/sendq protection on
+      // UnrealIRCd and dropping the connection (issue #116).
 
       // Check if current user has operator status in this channel and update their modes
       const currentUser = state.currentUser;

--- a/src/store/handlers/channels.ts
+++ b/src/store/handlers/channels.ts
@@ -405,13 +405,7 @@ export function registerChannelHandlers(store: StoreApi<AppState>): void {
         }
         return server;
       });
-
-      // Per-user metadata is fetched lazily now (MemberList scroll-stop
-      // visibility + CHANMSG/USERMSG speak triggers). On a 200-user
-      // channel this loop used to fire 200 METADATA LIST commands in a
-      // tight burst on JOIN, tripping recvq/sendq protection on
-      // UnrealIRCd and dropping the connection (issue #116).
-
+      
       // Check if current user has operator status in this channel and update their modes
       const currentUser = state.currentUser;
       if (currentUser) {

--- a/src/store/handlers/connection.ts
+++ b/src/store/handlers/connection.ts
@@ -146,17 +146,13 @@ export function registerConnectionHandlers(store: StoreApi<AppState>): void {
     // Subscribe and sync own metadata in the background — don't await so channel joins
     // happen immediately. The metadata send runs 1 s later inside fetchAndMergeOwnMetadata.
     if (serverSupportsMetadata(store.getState(), serverId)) {
-      // Always re-send SUB on every connect — some servers don't persist subscriptions across sessions.
-      const defaultKeys = [
-        "url",
-        "website",
-        "status",
-        "location",
-        "avatar",
-        "color",
-        "display-name",
-        "bot",
-      ];
+      // Narrow SUB to two keys (display-name, avatar) so the server's
+      // "metadata firehose" on JOIN doesn't push 8 keys × N users at us
+      // and trip recvq/sendq protection on big channels. Other keys are
+      // pulled lazily via metadataList when the user is visible in the
+      // nicklist or speaks. Re-sent on every connect because some
+      // servers don't persist subscriptions across sessions.
+      const defaultKeys = ["display-name", "avatar"];
       store.getState().metadataSub(serverId, defaultKeys);
 
       fetchAndMergeOwnMetadata(store, serverId).then(() => {

--- a/src/store/handlers/connection.ts
+++ b/src/store/handlers/connection.ts
@@ -143,18 +143,22 @@ export function registerConnectionHandlers(store: StoreApi<AppState>): void {
       });
     }
 
-    // Subscribe and sync own metadata in the background — don't await so channel joins
-    // happen immediately. The metadata send runs 1 s later inside fetchAndMergeOwnMetadata.
+    // Sync our own metadata in the background -- don't await so channel
+    // joins happen immediately.
+    //
+    // We deliberately do NOT send METADATA SUB any more. The server's
+    // join-time push of every subscribed key for every existing channel
+    // member is the "metadata firehose": on a 500-user channel that's
+    // hundreds of pushes in a burst, in the server's internal iteration
+    // order (which on rejoin appears reverse-of-set, so users see
+    // avatars/display-names trickling in from the bottom of the
+    // nicklist). Since the client already lazy-GETs metadata as nicks
+    // come into view (MemberList.flushVisible), SUB is pure overhead --
+    // we'd be paying the firehose cost twice (once for SUB push, once
+    // for our own GETs). Live updates after the initial GET are not
+    // visible to us, but display-name / avatar don't change often and
+    // the profile modal re-GETs anyway.
     if (serverSupportsMetadata(store.getState(), serverId)) {
-      // Narrow SUB to two keys (display-name, avatar) so the server's
-      // "metadata firehose" on JOIN doesn't push 8 keys × N users at us
-      // and trip recvq/sendq protection on big channels. Other keys are
-      // pulled lazily via metadataList when the user is visible in the
-      // nicklist or speaks. Re-sent on every connect because some
-      // servers don't persist subscriptions across sessions.
-      const defaultKeys = ["display-name", "avatar"];
-      store.getState().metadataSub(serverId, defaultKeys);
-
       fetchAndMergeOwnMetadata(store, serverId).then(() => {
         const savedMetadataAfterMerge = storage.metadata.load();
         const serverMetadataAfterMerge = savedMetadataAfterMerge[serverId];

--- a/src/store/handlers/messages.ts
+++ b/src/store/handlers/messages.ts
@@ -91,6 +91,12 @@ export function registerMessageHandlers(store: StoreApi<AppState>): void {
         const isOwnMessage =
           response.sender.toLowerCase() ===
           currentServerUser?.username?.toLowerCase();
+        // Lazy-fetch the sender's metadata the first time they speak in
+        // this session. metadataList() is idempotent + cached so the
+        // cost is one METADATA LIST per unique speaker.
+        if (!isOwnMessage && response.sender) {
+          store.getState().metadataList(response.serverId, response.sender);
+        }
         const isReplyToMe =
           !isOwnMessage &&
           !!replyMessage &&
@@ -750,6 +756,16 @@ export function registerMessageHandlers(store: StoreApi<AppState>): void {
       .servers.find((s) => s.id === response.serverId);
 
     if (server) {
+      // Lazy-fetch sender metadata on first PM, same as CHANMSG path.
+      // Skip server pseudo-sources (those have a "." in the source) and
+      // our own echoes.
+      const ourNick = ircClient
+        .getCurrentUser(response.serverId)
+        ?.username?.toLowerCase();
+      if (sender && !sender.includes(".") && sender.toLowerCase() !== ourNick) {
+        store.getState().metadataList(response.serverId, sender);
+      }
+
       // Check if this PRIVMSG is from the server itself (sender contains a ".")
       // Server messages should go to Server Notices, not create PM tabs
       if (sender.includes(".")) {

--- a/src/store/handlers/whois.ts
+++ b/src/store/handlers/whois.ts
@@ -3,6 +3,7 @@ import ircClient from "../../lib/ircClient";
 import type { User } from "../../types";
 import type { AppState } from "../index";
 import * as storage from "../localStorage";
+import { bufferWhoReply, flushWhoReplies } from "../whoReplyBatcher";
 
 export function registerWhoisHandlers(store: StoreApi<AppState>): void {
   // WHOIS event handlers
@@ -339,100 +340,31 @@ export function registerWhoisHandlers(store: StoreApi<AppState>): void {
         }
       }
 
-      // Create user object from WHO data with proper User type
-      const user: User = {
-        id: nick,
-        username: nick,
-        hostname: host, // Store the hostname from WHO reply
-        realname: realname, // Store the realname/gecos from WHO reply
-        avatar: undefined,
-        isOnline: true,
-        isAway: isAway,
-        isBot: false,
-        isIrcOp: flags ? flags.includes("*") : false, // Check for IRC operator flag
-        status: channelStatus, // Set the channel status here
-        metadata: {},
-      };
-      // Check for bot flags if bot mode is enabled
-      if (serverData.botMode) {
-        const botFlag = serverData.botMode;
-        const isBot = flags.includes(botFlag);
+      const botFlag = serverData.botMode;
+      const isBotFromFlags = !!(botFlag && flags?.includes(botFlag));
 
-        if (isBot) {
-          user.isBot = true;
-          user.metadata = {
-            bot: { value: "true", visibility: "public" },
-          };
-        }
-      }
-
-      // Load saved metadata for this user from localStorage
-      const savedMetadata = storage.metadata.load();
-      if (savedMetadata[serverId]?.[nick]) {
-        user.metadata = {
-          ...user.metadata,
-          ...savedMetadata[serverId][nick],
-        };
-      }
-
-      // Update the channel's user list with this user
-      store.setState((state) => {
-        const updatedServers = state.servers.map((s) => {
-          if (s.id === serverId) {
-            // Update channels
-            const updatedChannels = s.channels.map((ch) => {
-              if (ch.name === channel) {
-                // Check if user already exists in the list
-                const existingUserIndex = ch.users.findIndex(
-                  (u) => u.username === nick,
-                );
-
-                if (existingUserIndex !== -1) {
-                  // Update existing user
-                  const updatedUsers = [...ch.users];
-                  updatedUsers[existingUserIndex] = {
-                    ...updatedUsers[existingUserIndex],
-                    ...user,
-                    metadata: {
-                      ...updatedUsers[existingUserIndex].metadata,
-                      ...user.metadata,
-                    },
-                  };
-                  return { ...ch, users: updatedUsers };
-                }
-                // Add new user
-                return { ...ch, users: [...ch.users, user] };
-              }
-              return ch;
-            });
-
-            // Also update private chats if this user has a PM tab open
-            const updatedPrivateChats = s.privateChats.map((pm) => {
-              if (pm.username.toLowerCase() === nick.toLowerCase()) {
-                // Update the PM tab with realname from WHO
-                return {
-                  ...pm,
-                  realname: realname,
-                };
-              }
-              return pm;
-            });
-
-            return {
-              ...s,
-              channels: updatedChannels,
-              privateChats: updatedPrivateChats,
-            };
-          }
-          return s;
-        });
-
-        return { servers: updatedServers };
+      // Buffer this per-user update so we render the member list once
+      // for the whole WHO burst instead of N times.
+      bufferWhoReply(store, serverId, channel, {
+        nick,
+        host,
+        realname,
+        flags,
+        isAway,
+        isBot: isBotFromFlags,
+        isIrcOp: flags ? flags.includes("*") : false,
+        status: channelStatus,
       });
     },
   );
 
   ircClient.on("WHO_END", ({ serverId, mask }) => {
+    // Flush any pending batched WHO replies for this channel so the
+    // member list updates at the END_OF_WHO boundary instead of waiting
+    // out the idle timer.
+    if (mask?.startsWith("#")) {
+      flushWhoReplies(store, serverId, mask);
+    }
     // When WHO list is complete for a channel, request metadata for all users
     // This ensures we get current metadata for users who were already in the channel
     const state = store.getState();
@@ -503,6 +435,25 @@ export function registerWhoisHandlers(store: StoreApi<AppState>): void {
       const isBotFromFlags = flags.includes("B");
       const isIrcOpFromFlags = flags.includes("*");
       const accountValue = account === "0" ? undefined : account;
+
+      // Channel WHOX: buffer the per-user update so the member list
+      // renders once for the whole WHO burst, not N times. PM-only
+      // refresh (no channel) falls through to the immediate setState
+      // path below since it's a single line, not part of a burst.
+      if (channel && channel !== "*") {
+        bufferWhoReply(store, serverId, channel, {
+          nick,
+          host,
+          realname,
+          flags,
+          account: accountValue ?? null,
+          isAway,
+          isBot: isBotFromFlags,
+          isIrcOp: isIrcOpFromFlags,
+          status: opLevel,
+        });
+        return;
+      }
 
       store.setState((state) => {
         const updatedServers = state.servers.map((s) => {

--- a/src/store/handlers/whois.ts
+++ b/src/store/handlers/whois.ts
@@ -1,7 +1,6 @@
 import type { StoreApi } from "zustand";
 import ircClient from "../../lib/ircClient";
 import type { User } from "../../types";
-import { serverSupportsMetadata } from "../helpers";
 import type { AppState } from "../index";
 import * as storage from "../localStorage";
 
@@ -444,19 +443,10 @@ export function registerWhoisHandlers(store: StoreApi<AppState>): void {
     const channelData = serverData.channels.find((c) => c.name === mask);
 
     if (channelData) {
-      // This was a WHO for a channel
-      // Only request metadata if server supports it
-      if (serverSupportsMetadata(state, serverId)) {
-        // Request metadata for all users in the channel
-        channelData.users.forEach((user) => {
-          // Only request if we don't already have metadata for this user
-          const hasMetadata =
-            user.metadata && Object.keys(user.metadata).length > 0;
-          if (!hasMetadata) {
-            store.getState().metadataList(serverId, user.username);
-          }
-        });
-      }
+      // This was a WHO for a channel.
+      // We used to fan out METADATA LIST to every user here, which is
+      // the same firehose pattern that NAMES dropped. Lazy fetching
+      // (MemberList visibility + speak triggers) covers it now.
     } else {
       // This might be a WHO for an individual user (private chat)
       // If we got no WHO_REPLY before this WHO_END, the user is offline

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -20,6 +20,7 @@ import { readyProcessedServers } from "./handlers/connection";
 import * as tictactoeActions from "./handlers/tictactoeActions";
 import { MAX_MESSAGES_PER_CHANNEL } from "./helpers";
 import * as storage from "./localStorage";
+import { enqueueMetadataList } from "./metadataLazyQueue";
 import { runPendingMigrations } from "./migrations";
 import type {
   ChannelOrderMap,
@@ -3714,7 +3715,10 @@ const useStore = create<AppState>((set, get) => ({
       },
     }));
 
-    ircClient.metadataList(serverId, target);
+    // Drip-feed through the lazy queue so a bursty source (scroll-stop
+    // on a wall of unfamiliar nicks, NAMES landing, etc.) doesn't trip
+    // server-side recvq flood protection.
+    enqueueMetadataList(ircClient, serverId, target);
   },
 
   metadataSet: (serverId, target, key, value, visibility) => {

--- a/src/store/localStorage.ts
+++ b/src/store/localStorage.ts
@@ -28,13 +28,25 @@ export const servers = {
   },
 };
 
+// In-memory metadata cache. We intentionally do NOT persist user/channel
+// metadata across page reloads: with random-uuid nicks (cat-bot tests)
+// or rapidly-rotating display-names, stale entries pollute resolveUser-
+// Metadata and the metadataList skip-if-cached check, making the
+// nicklist look blank even after a fresh GET would have populated it.
+// Memory-only is fine because (a) we lazy-GET on visibility anyway, and
+// (b) localStorage churn from constant metadata writes wasn't paying
+// for itself. Wipe any pre-existing key so old persisted data doesn't
+// hang around in localStorage forever.
+try {
+  localStorage.removeItem(KEYS.METADATA);
+} catch {
+  // private-window or storage-disabled -- not fatal
+}
+let metadataCache: SavedMetadata = {};
 export const metadata = {
-  load: (): SavedMetadata => {
-    return JSON.parse(localStorage.getItem(KEYS.METADATA) || "{}");
-  },
-
+  load: (): SavedMetadata => metadataCache,
   save: (data: SavedMetadata) => {
-    localStorage.setItem(KEYS.METADATA, JSON.stringify(data));
+    metadataCache = data;
   },
 };
 

--- a/src/store/metadataLazyQueue.ts
+++ b/src/store/metadataLazyQueue.ts
@@ -1,0 +1,71 @@
+// Drip-feeds METADATA LIST commands to the server so a "scroll-stops on
+// 30 unfamiliar nicks" burst, or a sudden run of speakers in a busy
+// channel, doesn't fire 30 lines at once and trip UnrealIRCd's recvq
+// flood protection (issue #116). Existing deduplication lives in the
+// store action -- this module only handles pacing.
+//
+// At ~5 requests/sec the network cost is amortised: a 200-user channel
+// where everything is cold takes ~40 s to fully populate, but the user
+// can use the channel immediately and population happens in the
+// background as users scroll / speak.
+
+import type ircClientType from "../lib/ircClient";
+
+// 200 ms per dispatch == 5 requests/sec, comfortably under UnrealIRCd's
+// default per-user recvq drain and well below most server-side flood
+// thresholds.
+const DRIP_INTERVAL_MS = 200;
+
+interface QueueEntry {
+  serverId: string;
+  target: string;
+}
+
+let queue: QueueEntry[] = [];
+let timer: ReturnType<typeof setInterval> | undefined;
+let injectedClient: typeof ircClientType | undefined;
+
+function tick() {
+  const next = queue.shift();
+  if (!next) {
+    if (timer) {
+      clearInterval(timer);
+      timer = undefined;
+    }
+    return;
+  }
+  const client = injectedClient;
+  if (!client) return;
+  client.metadataList(next.serverId, next.target);
+}
+
+export function enqueueMetadataList(
+  client: typeof ircClientType,
+  serverId: string,
+  target: string,
+): void {
+  injectedClient = client;
+  // Coalesce duplicates that slipped past the store-level dedup (e.g.
+  // a speaker who's also visible in the nicklist).
+  if (queue.some((e) => e.serverId === serverId && e.target === target)) {
+    return;
+  }
+  queue.push({ serverId, target });
+  if (!timer) {
+    timer = setInterval(tick, DRIP_INTERVAL_MS);
+  }
+}
+
+// Test-only helpers.
+export function _resetMetadataLazyQueue(): void {
+  queue = [];
+  if (timer) {
+    clearInterval(timer);
+    timer = undefined;
+  }
+  injectedClient = undefined;
+}
+
+export function _peekMetadataLazyQueue(): QueueEntry[] {
+  return queue.slice();
+}

--- a/src/store/whoReplyBatcher.ts
+++ b/src/store/whoReplyBatcher.ts
@@ -1,0 +1,198 @@
+// Coalesces 352/354 WHO replies so the member list renders once, not
+// once per user. Both WHO_REPLY (RFC 1459 RPL_WHOREPLY) and WHOX_REPLY
+// (RPL_WHOSPCRPL, /WHO ... %xxx) arrive one per user. On a big channel
+// that's hundreds of immediate `store.setState`s, each remapping every
+// server/channel/user -- React re-renders the MemberList that many
+// times and the user sees the list tick in one nick at a time.
+//
+// Pattern: each incoming reply pushes a pending update into a per-
+// (serverId, channelName) buffer. A short idle timer (FLUSH_IDLE_MS)
+// flushes the entire buffer in one setState. An optional hard ceiling
+// flushes anyway so very slow servers don't appear stalled.
+
+import type { StoreApi } from "zustand";
+import type { User } from "../types";
+import type { AppState } from "./index";
+
+// 60 ms: long enough for a single WHO burst to coalesce on common
+// networks, short enough that the perceived "loading" is brief.
+const FLUSH_IDLE_MS = 60;
+// 1000 ms: hard ceiling so a trickling WHO (slow server, link
+// degradation) still produces visible progress.
+const FLUSH_MAX_MS = 1000;
+
+export interface BufferedWhoEntry {
+  nick: string;
+  username?: string;
+  host?: string;
+  realname?: string;
+  flags?: string;
+  account?: string | null; // null === explicit "0" / no account
+  isAway?: boolean;
+  isBot?: boolean;
+  isIrcOp?: boolean;
+  status?: string; // channel prefix flags like "@", "%", etc.
+}
+
+interface ChannelBucket {
+  serverId: string;
+  channel: string;
+  byNick: Map<string, BufferedWhoEntry>;
+  idleTimer: ReturnType<typeof setTimeout> | undefined;
+  ceilingTimer: ReturnType<typeof setTimeout> | undefined;
+}
+
+const buckets = new Map<string, ChannelBucket>();
+
+function key(serverId: string, channel: string): string {
+  return `${serverId}|${channel.toLowerCase()}`;
+}
+
+function applyBucket(store: StoreApi<AppState>, bucket: ChannelBucket): void {
+  if (bucket.idleTimer) {
+    clearTimeout(bucket.idleTimer);
+    bucket.idleTimer = undefined;
+  }
+  if (bucket.ceilingTimer) {
+    clearTimeout(bucket.ceilingTimer);
+    bucket.ceilingTimer = undefined;
+  }
+  buckets.delete(key(bucket.serverId, bucket.channel));
+  if (bucket.byNick.size === 0) return;
+
+  store.setState((state) => {
+    const updatedServers = state.servers.map((s) => {
+      if (s.id !== bucket.serverId) return s;
+
+      const updatedChannels = s.channels.map((ch) => {
+        if (ch.name.toLowerCase() !== bucket.channel.toLowerCase()) return ch;
+        const usersByNick = new Map(
+          ch.users.map((u) => [u.username.toLowerCase(), u] as const),
+        );
+        for (const entry of bucket.byNick.values()) {
+          const existing = usersByNick.get(entry.nick.toLowerCase());
+          if (existing) {
+            usersByNick.set(
+              entry.nick.toLowerCase(),
+              mergeUser(existing, entry),
+            );
+          } else {
+            usersByNick.set(entry.nick.toLowerCase(), entryToUser(entry));
+          }
+        }
+        return { ...ch, users: Array.from(usersByNick.values()) };
+      });
+
+      // Mirror to private chats (PM tab metadata such as realname,
+      // account, online/away status).
+      const updatedPrivateChats = (s.privateChats || []).map((pm) => {
+        const entry = bucket.byNick.get(pm.username.toLowerCase());
+        if (!entry) return pm;
+        return {
+          ...pm,
+          username: entry.nick, // case correction
+          realname: entry.realname ?? pm.realname,
+          account: entry.account ?? pm.account,
+          isOnline: true,
+          isAway: entry.isAway ?? pm.isAway,
+          isBot: (pm.isBot || entry.isBot) ?? pm.isBot,
+          isIrcOp: entry.isIrcOp ?? pm.isIrcOp,
+        };
+      });
+
+      return {
+        ...s,
+        channels: updatedChannels,
+        privateChats: updatedPrivateChats,
+      };
+    });
+
+    return { servers: updatedServers };
+  });
+}
+
+function mergeUser(prev: User, entry: BufferedWhoEntry): User {
+  return {
+    ...prev,
+    username: entry.nick, // server-authoritative casing
+    hostname: entry.host ?? prev.hostname,
+    realname: entry.realname ?? prev.realname,
+    account: entry.account ?? prev.account,
+    isOnline: true,
+    isAway: entry.isAway ?? prev.isAway,
+    isBot: entry.isBot ?? prev.isBot,
+    isIrcOp: entry.isIrcOp ?? prev.isIrcOp,
+    status: entry.status ?? prev.status,
+  };
+}
+
+function entryToUser(entry: BufferedWhoEntry): User {
+  return {
+    id: entry.nick,
+    username: entry.nick,
+    hostname: entry.host,
+    realname: entry.realname,
+    avatar: undefined,
+    isOnline: true,
+    isAway: !!entry.isAway,
+    isBot: !!entry.isBot,
+    isIrcOp: !!entry.isIrcOp,
+    status: entry.status,
+    account: entry.account ?? undefined,
+    metadata: {},
+  };
+}
+
+export function bufferWhoReply(
+  store: StoreApi<AppState>,
+  serverId: string,
+  channel: string,
+  entry: BufferedWhoEntry,
+): void {
+  const k = key(serverId, channel);
+  const existing = buckets.get(k);
+  const bucket: ChannelBucket = existing ?? {
+    serverId,
+    channel,
+    byNick: new Map(),
+    idleTimer: undefined,
+    ceilingTimer: undefined,
+  };
+  if (!existing) {
+    buckets.set(k, bucket);
+    bucket.ceilingTimer = setTimeout(
+      () => applyBucket(store, bucket),
+      FLUSH_MAX_MS,
+    );
+  }
+  // Last-write-wins per nick within a burst (the most recent WHO line
+  // for a given user is the authoritative one).
+  bucket.byNick.set(entry.nick.toLowerCase(), entry);
+  if (bucket.idleTimer) clearTimeout(bucket.idleTimer);
+  bucket.idleTimer = setTimeout(
+    () => applyBucket(store, bucket),
+    FLUSH_IDLE_MS,
+  );
+}
+
+export function flushWhoReplies(
+  store: StoreApi<AppState>,
+  serverId: string,
+  channel: string,
+): void {
+  const bucket = buckets.get(key(serverId, channel));
+  if (bucket) applyBucket(store, bucket);
+}
+
+// Test-only helpers.
+export function _resetWhoReplyBatcher(): void {
+  for (const b of buckets.values()) {
+    if (b.idleTimer) clearTimeout(b.idleTimer);
+    if (b.ceilingTimer) clearTimeout(b.ceilingTimer);
+  }
+  buckets.clear();
+}
+
+export function _peekWhoReplyBatcher(serverId: string, channel: string) {
+  return buckets.get(key(serverId, channel));
+}

--- a/tests/store/join.test.ts
+++ b/tests/store/join.test.ts
@@ -1,8 +1,9 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import ircClient from "../../src/lib/ircClient";
 import type { AppState } from "../../src/store";
 import useStore from "../../src/store";
 import { readyProcessedServers } from "../../src/store/handlers/connection";
+import * as storage from "../../src/store/localStorage";
 import type { Channel } from "../../src/types";
 
 function makeChannel(overrides: Partial<Channel> = {}): Channel {
@@ -46,19 +47,20 @@ const AVATAR_META = {
   avatar: { value: "http://cdn.example.com/avatar.png", visibility: "public" },
 };
 
-// storage.metadata.load() reads localStorage.getItem("serverMetadata")
-function mockLocalStorageMeta(data: Record<string, unknown>) {
-  vi.mocked(window.localStorage.getItem).mockReturnValue(JSON.stringify(data));
+// metadata is now an in-memory module cache; seed it via storage.metadata.save().
+// biome-ignore lint/suspicious/noExplicitAny: test helper accepts loose shape
+function seedMetadata(data: Record<string, any>) {
+  storage.metadata.save(data);
 }
 
 describe("live JOIN — metadata restoration", () => {
   beforeEach(() => {
     setupServer();
-    vi.mocked(window.localStorage.getItem).mockReturnValue("{}");
+    storage.metadata.save({});
   });
 
   it("attaches localStorage metadata to user on live join", () => {
-    mockLocalStorageMeta({ "srv-1": { bob: AVATAR_META } });
+    seedMetadata({ "srv-1": { bob: AVATAR_META } });
 
     ircClient.triggerEvent("JOIN", {
       serverId: "srv-1",

--- a/tests/store/metadataLazyQueue.test.ts
+++ b/tests/store/metadataLazyQueue.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  _peekMetadataLazyQueue,
+  _resetMetadataLazyQueue,
+  enqueueMetadataList,
+} from "../../src/store/metadataLazyQueue";
+
+function makeMockClient() {
+  return {
+    metadataList: vi.fn(),
+  } as unknown as Parameters<typeof enqueueMetadataList>[0];
+}
+
+describe("metadataLazyQueue", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    _resetMetadataLazyQueue();
+  });
+
+  afterEach(() => {
+    _resetMetadataLazyQueue();
+    vi.useRealTimers();
+  });
+
+  test("drips one METADATA LIST per interval, in order", () => {
+    const client = makeMockClient();
+    enqueueMetadataList(client, "s1", "alice");
+    enqueueMetadataList(client, "s1", "bob");
+    enqueueMetadataList(client, "s1", "carol");
+
+    expect(client.metadataList).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(200);
+    expect(client.metadataList).toHaveBeenCalledTimes(1);
+    expect(client.metadataList).toHaveBeenLastCalledWith("s1", "alice");
+
+    vi.advanceTimersByTime(200);
+    expect(client.metadataList).toHaveBeenCalledTimes(2);
+    expect(client.metadataList).toHaveBeenLastCalledWith("s1", "bob");
+
+    vi.advanceTimersByTime(200);
+    expect(client.metadataList).toHaveBeenCalledTimes(3);
+    expect(client.metadataList).toHaveBeenLastCalledWith("s1", "carol");
+  });
+
+  test("coalesces duplicate (serverId,target) pairs already in the queue", () => {
+    const client = makeMockClient();
+    enqueueMetadataList(client, "s1", "alice");
+    enqueueMetadataList(client, "s1", "alice");
+    enqueueMetadataList(client, "s1", "alice");
+
+    expect(_peekMetadataLazyQueue()).toHaveLength(1);
+    vi.advanceTimersByTime(200);
+    expect(client.metadataList).toHaveBeenCalledTimes(1);
+  });
+
+  test("same target on different servers is not coalesced", () => {
+    const client = makeMockClient();
+    enqueueMetadataList(client, "s1", "alice");
+    enqueueMetadataList(client, "s2", "alice");
+    expect(_peekMetadataLazyQueue()).toHaveLength(2);
+    vi.advanceTimersByTime(200);
+    vi.advanceTimersByTime(200);
+    expect(client.metadataList).toHaveBeenCalledTimes(2);
+    expect(client.metadataList).toHaveBeenNthCalledWith(1, "s1", "alice");
+    expect(client.metadataList).toHaveBeenNthCalledWith(2, "s2", "alice");
+  });
+
+  test("idles when the queue empties and resumes on next enqueue", () => {
+    const client = makeMockClient();
+    enqueueMetadataList(client, "s1", "alice");
+    vi.advanceTimersByTime(200);
+    expect(client.metadataList).toHaveBeenCalledTimes(1);
+
+    // Queue is now empty and the timer should be cleared. Advance many
+    // intervals — nothing should happen until we enqueue again.
+    vi.advanceTimersByTime(10_000);
+    expect(client.metadataList).toHaveBeenCalledTimes(1);
+
+    enqueueMetadataList(client, "s1", "bob");
+    vi.advanceTimersByTime(200);
+    expect(client.metadataList).toHaveBeenCalledTimes(2);
+    expect(client.metadataList).toHaveBeenLastCalledWith("s1", "bob");
+  });
+});

--- a/tests/store/whoReplyBatcher.test.ts
+++ b/tests/store/whoReplyBatcher.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { StoreApi } from "zustand";
+import {
+  _peekWhoReplyBatcher,
+  _resetWhoReplyBatcher,
+  bufferWhoReply,
+  flushWhoReplies,
+} from "../../src/store/whoReplyBatcher";
+
+function makeMockStore() {
+  const setCalls: unknown[] = [];
+  let state: {
+    servers: Array<{
+      id: string;
+      channels: Array<{
+        name: string;
+        users: Array<{
+          id: string;
+          username: string;
+          metadata: Record<string, unknown>;
+          [k: string]: unknown;
+        }>;
+      }>;
+      privateChats?: Array<{
+        username: string;
+        [k: string]: unknown;
+      }>;
+    }>;
+  } = {
+    servers: [
+      {
+        id: "s1",
+        channels: [
+          { name: "#room", users: [] },
+          { name: "#other", users: [] },
+        ],
+        privateChats: [],
+      },
+    ],
+  };
+  return {
+    setState: vi.fn((updater: unknown) => {
+      setCalls.push(updater);
+      if (typeof updater === "function") {
+        const patch = (updater as (s: typeof state) => Partial<typeof state>)(
+          state,
+        );
+        state = { ...state, ...patch };
+      }
+    }),
+    getState: () => state,
+    // biome-ignore lint/suspicious/noExplicitAny: minimal mock
+    subscribe: vi.fn() as any,
+    setCalls,
+    snapshot: () => state,
+    // biome-ignore lint/suspicious/noExplicitAny: minimal mock
+  } as unknown as StoreApi<any> & {
+    setCalls: unknown[];
+    snapshot: () => typeof state;
+  };
+}
+
+describe("whoReplyBatcher", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    _resetWhoReplyBatcher();
+  });
+
+  afterEach(() => {
+    _resetWhoReplyBatcher();
+    vi.useRealTimers();
+  });
+
+  test("coalesces N WHO replies into a single setState after idle", () => {
+    const store = makeMockStore();
+    for (let i = 0; i < 50; i++) {
+      bufferWhoReply(store, "s1", "#room", {
+        nick: `user${i}`,
+        host: "h.example",
+        realname: `Real ${i}`,
+        status: "",
+      });
+    }
+    expect(store.setState).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(59);
+    expect(store.setState).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(2);
+    expect(store.setState).toHaveBeenCalledTimes(1);
+    const finalUsers = store.snapshot().servers[0].channels[0].users;
+    expect(finalUsers).toHaveLength(50);
+    expect(finalUsers[0].username).toBe("user0");
+    expect(finalUsers[49].username).toBe("user49");
+  });
+
+  test("last-write-wins per nick within a single burst", () => {
+    const store = makeMockStore();
+    bufferWhoReply(store, "s1", "#room", {
+      nick: "alice",
+      realname: "first",
+      host: "first.host",
+    });
+    bufferWhoReply(store, "s1", "#room", {
+      nick: "alice",
+      realname: "second",
+      host: "second.host",
+    });
+    vi.advanceTimersByTime(70);
+    const u = store.snapshot().servers[0].channels[0].users[0];
+    expect(u.realname).toBe("second");
+    expect(u.hostname).toBe("second.host");
+  });
+
+  test("explicit flushWhoReplies bypasses the idle wait (WHO_END path)", () => {
+    const store = makeMockStore();
+    bufferWhoReply(store, "s1", "#room", { nick: "bob" });
+    expect(store.setState).not.toHaveBeenCalled();
+    flushWhoReplies(store, "s1", "#room");
+    expect(store.setState).toHaveBeenCalledTimes(1);
+    expect(_peekWhoReplyBatcher("s1", "#room")).toBeUndefined();
+  });
+
+  test("a trickling WHO still flushes via the ceiling timer", () => {
+    const store = makeMockStore();
+    // Push a reply, then keep re-arming idle just under 60ms apart so
+    // the idle timer NEVER fires. Ceiling at 1000ms should still flush.
+    for (let i = 0; i < 30; i++) {
+      bufferWhoReply(store, "s1", "#room", { nick: `slow${i}` });
+      vi.advanceTimersByTime(30);
+    }
+    expect(store.setState).not.toHaveBeenCalled();
+    // One more push to make the elapsed time exceed FLUSH_MAX_MS overall
+    vi.advanceTimersByTime(200);
+    expect(store.setState).toHaveBeenCalledTimes(1);
+    const users = store.snapshot().servers[0].channels[0].users;
+    expect(users).toHaveLength(30);
+  });
+
+  test("merges into existing users rather than appending duplicates", () => {
+    const store = makeMockStore();
+    // Seed: pretend alice was already in the user list from NAMES.
+    const s = store.snapshot();
+    s.servers[0].channels[0].users.push({
+      id: "alice",
+      username: "alice",
+      metadata: {},
+      realname: undefined,
+      hostname: undefined,
+    });
+    bufferWhoReply(store, "s1", "#room", {
+      nick: "alice",
+      host: "h.example",
+      realname: "Alice Cooper",
+      isIrcOp: true,
+    });
+    vi.advanceTimersByTime(70);
+    const users = store.snapshot().servers[0].channels[0].users;
+    expect(users).toHaveLength(1);
+    expect(users[0].realname).toBe("Alice Cooper");
+    expect(users[0].isIrcOp).toBe(true);
+    expect(users[0].hostname).toBe("h.example");
+  });
+
+  test("buckets are scoped per (serverId, channel)", () => {
+    const store = makeMockStore();
+    bufferWhoReply(store, "s1", "#room", { nick: "alice" });
+    bufferWhoReply(store, "s1", "#other", { nick: "bob" });
+    vi.advanceTimersByTime(70);
+    // Two distinct setState calls (one per bucket), each in a separate
+    // timer tick.
+    expect(store.setState).toHaveBeenCalledTimes(2);
+    const snap = store.snapshot();
+    expect(snap.servers[0].channels[0].users[0].username).toBe("alice");
+    expect(snap.servers[0].channels[1].users[0].username).toBe("bob");
+  });
+});


### PR DESCRIPTION
Closes #116.

## Root cause

On a 200+ user channel, joining the channel disconnects the client. Two hidden firehoses fire at JOIN time:

1. **NAMES handler** ([store/handlers/channels.ts](src/store/handlers/channels.ts)) iterated every user and called `metadataList(serverId, user)`, sending `METADATA <nick> LIST` once per user — ~200 lines in a burst.
2. **WHO handler** ([store/handlers/whois.ts](src/store/handlers/whois.ts)) did the same loop again after WHO_END — another ~200 lines.

The connect-time `METADATA * SUB` ([store/handlers/connection.ts](src/store/handlers/connection.ts)) was also subscribing to 8 keys, telling the server to push 8 × N values for every user we share a channel with — the spec-blessed "metadata firehose".

UnrealIRCd's recvq protection then ate the connection.

## Fix — fully lazy per-user metadata

| Trigger | What it does |
|---|---|
| **Speak** (`CHANMSG` / `USERMSG`) | First time a non-self user is heard from this session, queue a `METADATA LIST` for them. |
| **Nicklist visibility** | `IntersectionObserver` on each `UserItem` + 250 ms scroll-idle debounce. When the scroll comes to rest, fetch metadata for currently-visible nicks not yet requested. Mid-scroll visibility events don't fire fetches. |
| **Profile modal open** | (Existing behavior, unchanged.) |

The existing `userMetadataRequested: Record<serverId, Set<nick>>` store state deduplicates across all sources, so each unique nick is fetched at most once per session.

To bound bursts (e.g. scroll-stops on a wall of unfamiliar nicks), all `METADATA LIST` calls now go through a tiny drip queue — [src/store/metadataLazyQueue.ts](src/store/metadataLazyQueue.ts) — that paces dispatches at one every 200 ms. FIFO, coalesces duplicates, idles when empty.

## SUB narrowing

Kept a narrow SUB on `display-name` + `avatar` so the two user-visible bits still update live (rename / new avatar). Dropped `url`, `website`, `status`, `location`, `color`, `bot`. ~75% smaller firehose on JOIN, still nice live updates for the things people notice.

## Test plan

- [x] `npm run format`, `npm run fix:unsafe`, `npm run test` (789 pass / 1 skipped), `npm run build` clean
- [x] New `tests/store/metadataLazyQueue.test.ts` covers: FIFO drip, coalesce duplicates, per-server isolation, idle-resume after queue empties
- [x] Manual: join a 200+ user channel on UnrealIRCd — no disconnect, members trickle in metadata as you scroll
- [x] Manual: someone speaks for the first time — their avatar / display-name appears within 200–400 ms
- [x] Manual: profile modal still loads complete metadata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched to on-demand metadata fetching to reduce initial load and avoid a metadata “firehose”
  * Member list lazily requests metadata as users scroll, improving responsiveness
  * Metadata requests are queued/throttled and WHO replies are batched to cut redundant updates
  * Metadata storage moved to an in-memory cache (no persistent localStorage usage)

* **Tests**
  * Added tests for metadata queueing and WHO-reply batching; updated JOIN test setup
<!-- end of auto-generated comment: release notes by coderabbit.ai -->