### PR TITLE
fix(who): batch WHO/WHOX, don't render one-by-one

### DIFF
--- a/src/components/layout/MemberList.tsx
+++ b/src/components/layout/MemberList.tsx
@@ -426,12 +426,8 @@ export const MemberList: React.FC = () => {
     };
   }, [scheduleFlush]);
 
-  // When the channel changes, re-arm the initial sweep so the new
-  // top-of-list nicks get prefetched.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: scheduleFlush identity is stable
-  useEffect(() => {
-    scheduleFlush();
-  }, [selectedChannelId]);
+  // (Initial-sweep re-arm useEffect moved below sortedUsers declaration
+  //  -- see "memberlist sweep" comment further down.)
 
   const [userContextMenu, setUserContextMenu] = useState<{
     isOpen: boolean;
@@ -506,6 +502,17 @@ export const MemberList: React.FC = () => {
   // store. Updated synchronously during render -- read in callbacks
   // that fire after.
   sortedOrderRef.current = sortedUsers?.map((u) => u.username) ?? [];
+
+  // memberlist sweep: re-arm flushVisible whenever (a) the channel
+  // changes or (b) the user count changes -- in particular when it
+  // jumps from 0 to N as the batched WHO reply lands. Without this the
+  // very first flushVisible runs while sortedOrderRef is still empty
+  // (returns early, no fetch) and we then wait for a scroll event
+  // before any metadata is requested.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scheduleFlush identity is stable
+  useEffect(() => {
+    scheduleFlush();
+  }, [selectedChannelId, sortedUsers?.length]);
 
   const handleUsernameClick = (
     e: React.MouseEvent,

--- a/src/components/layout/MemberList.tsx
+++ b/src/components/layout/MemberList.tsx
@@ -398,13 +398,6 @@ export const MemberList: React.FC = () => {
       list(selectedServerId, username);
       queued++;
     }
-    if (typeof console !== "undefined" && typeof console.debug === "function") {
-      console.debug(
-        `[memberlist] flushVisible [${start},${end}) of ${order.length} ` +
-          `(scrollTop=${root.scrollTop}, h=${root.clientHeight}, item=${itemHeight}); ` +
-          `queued ${queued}`,
-      );
-    }
   }, [selectedServerId]);
 
   const scheduleFlush = useCallback(() => {

--- a/src/components/layout/MemberList.tsx
+++ b/src/components/layout/MemberList.tsx
@@ -100,16 +100,16 @@ const UserItem: React.FC<{
     channelId: string,
     avatarElement?: Element | null,
   ) => void;
-  // Lazy-metadata: parent observes each item with an IntersectionObserver
-  // so we only METADATA LIST users the user actually scrolls to.
-  registerObserverItem?: (username: string, el: Element | null) => void;
+  // The very first member item gets refMeasure(el) so the parent can
+  // sample offsetHeight for its scrollTop-based visibility math.
+  refMeasure?: (el: HTMLDivElement | null) => void;
 }> = ({
   user,
   serverId,
   channelId,
   currentUser,
   onContextMenu,
-  registerObserverItem,
+  refMeasure,
 }) => {
   const { t } = useLingui();
   const [avatarLoadFailed, setAvatarLoadFailed] = useState(false);
@@ -175,7 +175,7 @@ const UserItem: React.FC<{
 
   return (
     <div
-      ref={(el) => registerObserverItem?.(user.username, el)}
+      ref={refMeasure}
       data-username={user.username}
       className="flex items-center gap-3 py-2 px-3 mx-2 mb-1 rounded cursor-pointer bg-discord-dark-400/30 hover:bg-discord-dark-400/50 transition-colors"
       onClick={(e) => {
@@ -350,24 +350,25 @@ export const MemberList: React.FC = () => {
   };
   const { selectedChannelId } = currentSelection;
 
-  // Lazy-metadata wiring. We track which nicks the scroller has actually
-  // landed on (via IntersectionObserver), wait for scrolling to come to
-  // rest (SCROLL_IDLE_MS), then ask the store to METADATA LIST any
-  // currently-visible nick we haven't already requested. The store
-  // dedups + the lazy queue drips so a burst of visible nicks doesn't
-  // hammer the server (issue #116).
+  // Lazy-metadata wiring: on scroll-stop, compute which slice of
+  // sortedUsers is currently inside the scroll container's viewport
+  // (from scrollTop + clientHeight, not IntersectionObserver -- IO was
+  // misreporting on this layout, fetching members from the bottom of
+  // the list upward instead of from the visible top). Then dispatch
+  // METADATA LIST for that slice in top-to-bottom order. The store
+  // dedups and the lazy queue drips so a burst of new visible nicks
+  // can't hammer the server (issue #116).
   const SCROLL_IDLE_MS = 250;
-  // Defensive cap: if the IntersectionObserver ever reports too many
-  // items as visible at once (e.g. before layout has settled), we still
-  // only ever queue at most this many METADATA LISTs per scroll-stop.
+  // Cap per scroll-stop so a sudden landing on a wall of unfetched
+  // nicks doesn't queue hundreds at once.
   const MAX_FETCH_PER_FLUSH = 30;
+  // Render a couple of off-screen rows ahead/behind so the avatars are
+  // ready by the time the user scrolls to them.
+  const VISIBILITY_OVERSCAN = 5;
   const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const observerRef = useRef<IntersectionObserver | null>(null);
-  const itemsRef = useRef(new Map<string, Element>());
-  const visibleUsernamesRef = useRef(new Set<string>());
-  // Mirror of the current sorted member list so flushVisible can map a
-  // visible username back to its on-screen position and dispatch the
-  // top-of-list nicks first.
+  const firstItemRef = useRef<HTMLDivElement | null>(null);
+  // Mirror of the current sorted member list so flushVisible can map an
+  // index back to a nick without going through React state.
   const sortedOrderRef = useRef<string[]>([]);
   const flushTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
@@ -375,23 +376,34 @@ export const MemberList: React.FC = () => {
 
   const flushVisible = useCallback(() => {
     if (!selectedServerId) return;
-    const list = useStore.getState().metadataList;
-    const visible = visibleUsernamesRef.current;
-    if (visible.size === 0) return;
-    // Sort visible nicks by their on-screen position so we fetch from
-    // the top of the list downward, not in whatever order the IO
-    // happened to fire entries. Cap to MAX_FETCH_PER_FLUSH so a wonky
-    // initial intersection report (which can claim every item is
-    // visible until layout settles) can't drown the lazy queue.
+    const root = scrollContainerRef.current;
     const order = sortedOrderRef.current;
-    const indexOf = new Map(order.map((u, i) => [u, i] as const));
-    const ordered = Array.from(visible).sort((a, b) => {
-      const ai = indexOf.get(a) ?? Number.POSITIVE_INFINITY;
-      const bi = indexOf.get(b) ?? Number.POSITIVE_INFINITY;
-      return ai - bi;
-    });
-    for (const username of ordered.slice(0, MAX_FETCH_PER_FLUSH)) {
+    if (!root || order.length === 0) return;
+    const itemHeight = firstItemRef.current?.offsetHeight || 56;
+    const start = Math.max(
+      0,
+      Math.floor(root.scrollTop / itemHeight) - VISIBILITY_OVERSCAN,
+    );
+    const end = Math.min(
+      order.length,
+      Math.ceil((root.scrollTop + root.clientHeight) / itemHeight) +
+        VISIBILITY_OVERSCAN,
+    );
+    if (end <= start) return;
+    const list = useStore.getState().metadataList;
+    let queued = 0;
+    for (let i = start; i < end && queued < MAX_FETCH_PER_FLUSH; i++) {
+      const username = order[i];
+      if (!username) continue;
       list(selectedServerId, username);
+      queued++;
+    }
+    if (typeof console !== "undefined" && typeof console.debug === "function") {
+      console.debug(
+        `[memberlist] flushVisible [${start},${end}) of ${order.length} ` +
+          `(scrollTop=${root.scrollTop}, h=${root.clientHeight}, item=${itemHeight}); ` +
+          `queued ${queued}`,
+      );
     }
   }, [selectedServerId]);
 
@@ -400,56 +412,25 @@ export const MemberList: React.FC = () => {
     flushTimerRef.current = setTimeout(flushVisible, SCROLL_IDLE_MS);
   }, [flushVisible]);
 
-  const registerObserverItem = useCallback(
-    (username: string, el: Element | null) => {
-      if (!el) {
-        const old = itemsRef.current.get(username);
-        if (old && observerRef.current) observerRef.current.unobserve(old);
-        itemsRef.current.delete(username);
-        visibleUsernamesRef.current.delete(username);
-        return;
-      }
-      itemsRef.current.set(username, el);
-      observerRef.current?.observe(el);
-    },
-    [],
-  );
-
   useEffect(() => {
     const root = scrollContainerRef.current;
     if (!root) return;
-    const obs = new IntersectionObserver(
-      (entries) => {
-        for (const entry of entries) {
-          const username = (entry.target as HTMLElement).dataset.username;
-          if (!username) continue;
-          if (entry.isIntersecting) visibleUsernamesRef.current.add(username);
-          else visibleUsernamesRef.current.delete(username);
-        }
-        scheduleFlush();
-      },
-      { root, threshold: 0 },
-    );
-    observerRef.current = obs;
-    for (const el of itemsRef.current.values()) obs.observe(el);
     const onScroll = () => scheduleFlush();
     root.addEventListener("scroll", onScroll, { passive: true });
+    // Initial sweep once layout has settled so the topmost visible
+    // chunk gets fetched without requiring user interaction.
+    scheduleFlush();
     return () => {
-      obs.disconnect();
-      observerRef.current = null;
       root.removeEventListener("scroll", onScroll);
       if (flushTimerRef.current) clearTimeout(flushTimerRef.current);
     };
   }, [scheduleFlush]);
 
-  // Channel changes remount items so the observer naturally re-binds via
-  // the callback ref; reset the visibility set so we don't carry over
-  // a stale "X was visible" from the previous channel. The dep is
-  // intentionally selectedChannelId even though the body doesn't read
-  // it -- changing channel is the trigger.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: clear on channel switch is the intent
+  // When the channel changes, re-arm the initial sweep so the new
+  // top-of-list nicks get prefetched.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scheduleFlush identity is stable
   useEffect(() => {
-    visibleUsernamesRef.current.clear();
+    scheduleFlush();
   }, [selectedChannelId]);
 
   const [userContextMenu, setUserContextMenu] = useState<{
@@ -664,7 +645,7 @@ export const MemberList: React.FC = () => {
       <h3 className="text-xs font-semibold text-discord-channels-default uppercase mb-2 px-2">
         <Trans>Members — {sortedUsers?.length || 0}</Trans>
       </h3>
-      {sortedUsers?.map((user) => (
+      {sortedUsers?.map((user, idx) => (
         <UserItem
           key={user.id}
           user={user}
@@ -672,7 +653,13 @@ export const MemberList: React.FC = () => {
           channelId={selectedChannelId || ""}
           currentUser={currentUser}
           onContextMenu={handleUsernameClick}
-          registerObserverItem={registerObserverItem}
+          refMeasure={
+            idx === 0
+              ? (el) => {
+                  firstItemRef.current = el;
+                }
+              : undefined
+          }
         />
       ))}
 

--- a/src/components/layout/MemberList.tsx
+++ b/src/components/layout/MemberList.tsx
@@ -357,10 +357,18 @@ export const MemberList: React.FC = () => {
   // dedups + the lazy queue drips so a burst of visible nicks doesn't
   // hammer the server (issue #116).
   const SCROLL_IDLE_MS = 250;
+  // Defensive cap: if the IntersectionObserver ever reports too many
+  // items as visible at once (e.g. before layout has settled), we still
+  // only ever queue at most this many METADATA LISTs per scroll-stop.
+  const MAX_FETCH_PER_FLUSH = 30;
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const observerRef = useRef<IntersectionObserver | null>(null);
   const itemsRef = useRef(new Map<string, Element>());
   const visibleUsernamesRef = useRef(new Set<string>());
+  // Mirror of the current sorted member list so flushVisible can map a
+  // visible username back to its on-screen position and dispatch the
+  // top-of-list nicks first.
+  const sortedOrderRef = useRef<string[]>([]);
   const flushTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
@@ -368,7 +376,21 @@ export const MemberList: React.FC = () => {
   const flushVisible = useCallback(() => {
     if (!selectedServerId) return;
     const list = useStore.getState().metadataList;
-    for (const username of visibleUsernamesRef.current) {
+    const visible = visibleUsernamesRef.current;
+    if (visible.size === 0) return;
+    // Sort visible nicks by their on-screen position so we fetch from
+    // the top of the list downward, not in whatever order the IO
+    // happened to fire entries. Cap to MAX_FETCH_PER_FLUSH so a wonky
+    // initial intersection report (which can claim every item is
+    // visible until layout settles) can't drown the lazy queue.
+    const order = sortedOrderRef.current;
+    const indexOf = new Map(order.map((u, i) => [u, i] as const));
+    const ordered = Array.from(visible).sort((a, b) => {
+      const ai = indexOf.get(a) ?? Number.POSITIVE_INFINITY;
+      const bi = indexOf.get(b) ?? Number.POSITIVE_INFINITY;
+      return ai - bi;
+    });
+    for (const username of ordered.slice(0, MAX_FETCH_PER_FLUSH)) {
       list(selectedServerId, username);
     }
   }, [selectedServerId]);
@@ -422,10 +444,13 @@ export const MemberList: React.FC = () => {
 
   // Channel changes remount items so the observer naturally re-binds via
   // the callback ref; reset the visibility set so we don't carry over
-  // a stale "X was visible" from the previous channel.
+  // a stale "X was visible" from the previous channel. The dep is
+  // intentionally selectedChannelId even though the body doesn't read
+  // it -- changing channel is the trigger.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: clear on channel switch is the intent
   useEffect(() => {
     visibleUsernamesRef.current.clear();
-  }, []);
+  }, [selectedChannelId]);
 
   const [userContextMenu, setUserContextMenu] = useState<{
     isOpen: boolean;
@@ -495,6 +520,11 @@ export const MemberList: React.FC = () => {
     }
     return a.username.localeCompare(b.username);
   });
+  // Keep an order ref so flushVisible (a stable useCallback) can find
+  // each visible nick's on-screen position without going back into the
+  // store. Updated synchronously during render -- read in callbacks
+  // that fire after.
+  sortedOrderRef.current = sortedUsers?.map((u) => u.username) ?? [];
 
   const handleUsernameClick = (
     e: React.MouseEvent,

--- a/src/store/handlers/connection.ts
+++ b/src/store/handlers/connection.ts
@@ -143,18 +143,22 @@ export function registerConnectionHandlers(store: StoreApi<AppState>): void {
       });
     }
 
-    // Subscribe and sync own metadata in the background — don't await so channel joins
-    // happen immediately. The metadata send runs 1 s later inside fetchAndMergeOwnMetadata.
+    // Sync our own metadata in the background -- don't await so channel
+    // joins happen immediately.
+    //
+    // We deliberately do NOT send METADATA SUB any more. The server's
+    // join-time push of every subscribed key for every existing channel
+    // member is the "metadata firehose": on a 500-user channel that's
+    // hundreds of pushes in a burst, in the server's internal iteration
+    // order (which on rejoin appears reverse-of-set, so users see
+    // avatars/display-names trickling in from the bottom of the
+    // nicklist). Since the client already lazy-GETs metadata as nicks
+    // come into view (MemberList.flushVisible), SUB is pure overhead --
+    // we'd be paying the firehose cost twice (once for SUB push, once
+    // for our own GETs). Live updates after the initial GET are not
+    // visible to us, but display-name / avatar don't change often and
+    // the profile modal re-GETs anyway.
     if (serverSupportsMetadata(store.getState(), serverId)) {
-      // Narrow SUB to two keys (display-name, avatar) so the server's
-      // "metadata firehose" on JOIN doesn't push 8 keys × N users at us
-      // and trip recvq/sendq protection on big channels. Other keys are
-      // pulled lazily via metadataList when the user is visible in the
-      // nicklist or speaks. Re-sent on every connect because some
-      // servers don't persist subscriptions across sessions.
-      const defaultKeys = ["display-name", "avatar"];
-      store.getState().metadataSub(serverId, defaultKeys);
-
       fetchAndMergeOwnMetadata(store, serverId).then(() => {
         const savedMetadataAfterMerge = storage.metadata.load();
         const serverMetadataAfterMerge = savedMetadataAfterMerge[serverId];

--- a/src/store/handlers/whois.ts
+++ b/src/store/handlers/whois.ts
@@ -3,6 +3,7 @@ import ircClient from "../../lib/ircClient";
 import type { User } from "../../types";
 import type { AppState } from "../index";
 import * as storage from "../localStorage";
+import { bufferWhoReply, flushWhoReplies } from "../whoReplyBatcher";
 
 export function registerWhoisHandlers(store: StoreApi<AppState>): void {
   // WHOIS event handlers
@@ -339,100 +340,31 @@ export function registerWhoisHandlers(store: StoreApi<AppState>): void {
         }
       }
 
-      // Create user object from WHO data with proper User type
-      const user: User = {
-        id: nick,
-        username: nick,
-        hostname: host, // Store the hostname from WHO reply
-        realname: realname, // Store the realname/gecos from WHO reply
-        avatar: undefined,
-        isOnline: true,
-        isAway: isAway,
-        isBot: false,
-        isIrcOp: flags ? flags.includes("*") : false, // Check for IRC operator flag
-        status: channelStatus, // Set the channel status here
-        metadata: {},
-      };
-      // Check for bot flags if bot mode is enabled
-      if (serverData.botMode) {
-        const botFlag = serverData.botMode;
-        const isBot = flags.includes(botFlag);
+      const botFlag = serverData.botMode;
+      const isBotFromFlags = !!(botFlag && flags?.includes(botFlag));
 
-        if (isBot) {
-          user.isBot = true;
-          user.metadata = {
-            bot: { value: "true", visibility: "public" },
-          };
-        }
-      }
-
-      // Load saved metadata for this user from localStorage
-      const savedMetadata = storage.metadata.load();
-      if (savedMetadata[serverId]?.[nick]) {
-        user.metadata = {
-          ...user.metadata,
-          ...savedMetadata[serverId][nick],
-        };
-      }
-
-      // Update the channel's user list with this user
-      store.setState((state) => {
-        const updatedServers = state.servers.map((s) => {
-          if (s.id === serverId) {
-            // Update channels
-            const updatedChannels = s.channels.map((ch) => {
-              if (ch.name === channel) {
-                // Check if user already exists in the list
-                const existingUserIndex = ch.users.findIndex(
-                  (u) => u.username === nick,
-                );
-
-                if (existingUserIndex !== -1) {
-                  // Update existing user
-                  const updatedUsers = [...ch.users];
-                  updatedUsers[existingUserIndex] = {
-                    ...updatedUsers[existingUserIndex],
-                    ...user,
-                    metadata: {
-                      ...updatedUsers[existingUserIndex].metadata,
-                      ...user.metadata,
-                    },
-                  };
-                  return { ...ch, users: updatedUsers };
-                }
-                // Add new user
-                return { ...ch, users: [...ch.users, user] };
-              }
-              return ch;
-            });
-
-            // Also update private chats if this user has a PM tab open
-            const updatedPrivateChats = s.privateChats.map((pm) => {
-              if (pm.username.toLowerCase() === nick.toLowerCase()) {
-                // Update the PM tab with realname from WHO
-                return {
-                  ...pm,
-                  realname: realname,
-                };
-              }
-              return pm;
-            });
-
-            return {
-              ...s,
-              channels: updatedChannels,
-              privateChats: updatedPrivateChats,
-            };
-          }
-          return s;
-        });
-
-        return { servers: updatedServers };
+      // Buffer this per-user update so we render the member list once
+      // for the whole WHO burst instead of N times.
+      bufferWhoReply(store, serverId, channel, {
+        nick,
+        host,
+        realname,
+        flags,
+        isAway,
+        isBot: isBotFromFlags,
+        isIrcOp: flags ? flags.includes("*") : false,
+        status: channelStatus,
       });
     },
   );
 
   ircClient.on("WHO_END", ({ serverId, mask }) => {
+    // Flush any pending batched WHO replies for this channel so the
+    // member list updates at the END_OF_WHO boundary instead of waiting
+    // out the idle timer.
+    if (mask?.startsWith("#")) {
+      flushWhoReplies(store, serverId, mask);
+    }
     // When WHO list is complete for a channel, request metadata for all users
     // This ensures we get current metadata for users who were already in the channel
     const state = store.getState();
@@ -503,6 +435,25 @@ export function registerWhoisHandlers(store: StoreApi<AppState>): void {
       const isBotFromFlags = flags.includes("B");
       const isIrcOpFromFlags = flags.includes("*");
       const accountValue = account === "0" ? undefined : account;
+
+      // Channel WHOX: buffer the per-user update so the member list
+      // renders once for the whole WHO burst, not N times. PM-only
+      // refresh (no channel) falls through to the immediate setState
+      // path below since it's a single line, not part of a burst.
+      if (channel && channel !== "*") {
+        bufferWhoReply(store, serverId, channel, {
+          nick,
+          host,
+          realname,
+          flags,
+          account: accountValue ?? null,
+          isAway,
+          isBot: isBotFromFlags,
+          isIrcOp: isIrcOpFromFlags,
+          status: opLevel,
+        });
+        return;
+      }
 
       store.setState((state) => {
         const updatedServers = state.servers.map((s) => {

--- a/src/store/localStorage.ts
+++ b/src/store/localStorage.ts
@@ -28,13 +28,25 @@ export const servers = {
   },
 };
 
+// In-memory metadata cache. We intentionally do NOT persist user/channel
+// metadata across page reloads: with random-uuid nicks (cat-bot tests)
+// or rapidly-rotating display-names, stale entries pollute resolveUser-
+// Metadata and the metadataList skip-if-cached check, making the
+// nicklist look blank even after a fresh GET would have populated it.
+// Memory-only is fine because (a) we lazy-GET on visibility anyway, and
+// (b) localStorage churn from constant metadata writes wasn't paying
+// for itself. Wipe any pre-existing key so old persisted data doesn't
+// hang around in localStorage forever.
+try {
+  localStorage.removeItem(KEYS.METADATA);
+} catch {
+  // private-window or storage-disabled -- not fatal
+}
+let metadataCache: SavedMetadata = {};
 export const metadata = {
-  load: (): SavedMetadata => {
-    return JSON.parse(localStorage.getItem(KEYS.METADATA) || "{}");
-  },
-
+  load: (): SavedMetadata => metadataCache,
   save: (data: SavedMetadata) => {
-    localStorage.setItem(KEYS.METADATA, JSON.stringify(data));
+    metadataCache = data;
   },
 };
 

--- a/src/store/whoReplyBatcher.ts
+++ b/src/store/whoReplyBatcher.ts
@@ -1,0 +1,198 @@
+// Coalesces 352/354 WHO replies so the member list renders once, not
+// once per user. Both WHO_REPLY (RFC 1459 RPL_WHOREPLY) and WHOX_REPLY
+// (RPL_WHOSPCRPL, /WHO ... %xxx) arrive one per user. On a big channel
+// that's hundreds of immediate `store.setState`s, each remapping every
+// server/channel/user -- React re-renders the MemberList that many
+// times and the user sees the list tick in one nick at a time.
+//
+// Pattern: each incoming reply pushes a pending update into a per-
+// (serverId, channelName) buffer. A short idle timer (FLUSH_IDLE_MS)
+// flushes the entire buffer in one setState. An optional hard ceiling
+// flushes anyway so very slow servers don't appear stalled.
+
+import type { StoreApi } from "zustand";
+import type { User } from "../types";
+import type { AppState } from "./index";
+
+// 60 ms: long enough for a single WHO burst to coalesce on common
+// networks, short enough that the perceived "loading" is brief.
+const FLUSH_IDLE_MS = 60;
+// 1000 ms: hard ceiling so a trickling WHO (slow server, link
+// degradation) still produces visible progress.
+const FLUSH_MAX_MS = 1000;
+
+export interface BufferedWhoEntry {
+  nick: string;
+  username?: string;
+  host?: string;
+  realname?: string;
+  flags?: string;
+  account?: string | null; // null === explicit "0" / no account
+  isAway?: boolean;
+  isBot?: boolean;
+  isIrcOp?: boolean;
+  status?: string; // channel prefix flags like "@", "%", etc.
+}
+
+interface ChannelBucket {
+  serverId: string;
+  channel: string;
+  byNick: Map<string, BufferedWhoEntry>;
+  idleTimer: ReturnType<typeof setTimeout> | undefined;
+  ceilingTimer: ReturnType<typeof setTimeout> | undefined;
+}
+
+const buckets = new Map<string, ChannelBucket>();
+
+function key(serverId: string, channel: string): string {
+  return `${serverId}|${channel.toLowerCase()}`;
+}
+
+function applyBucket(store: StoreApi<AppState>, bucket: ChannelBucket): void {
+  if (bucket.idleTimer) {
+    clearTimeout(bucket.idleTimer);
+    bucket.idleTimer = undefined;
+  }
+  if (bucket.ceilingTimer) {
+    clearTimeout(bucket.ceilingTimer);
+    bucket.ceilingTimer = undefined;
+  }
+  buckets.delete(key(bucket.serverId, bucket.channel));
+  if (bucket.byNick.size === 0) return;
+
+  store.setState((state) => {
+    const updatedServers = state.servers.map((s) => {
+      if (s.id !== bucket.serverId) return s;
+
+      const updatedChannels = s.channels.map((ch) => {
+        if (ch.name.toLowerCase() !== bucket.channel.toLowerCase()) return ch;
+        const usersByNick = new Map(
+          ch.users.map((u) => [u.username.toLowerCase(), u] as const),
+        );
+        for (const entry of bucket.byNick.values()) {
+          const existing = usersByNick.get(entry.nick.toLowerCase());
+          if (existing) {
+            usersByNick.set(
+              entry.nick.toLowerCase(),
+              mergeUser(existing, entry),
+            );
+          } else {
+            usersByNick.set(entry.nick.toLowerCase(), entryToUser(entry));
+          }
+        }
+        return { ...ch, users: Array.from(usersByNick.values()) };
+      });
+
+      // Mirror to private chats (PM tab metadata such as realname,
+      // account, online/away status).
+      const updatedPrivateChats = (s.privateChats || []).map((pm) => {
+        const entry = bucket.byNick.get(pm.username.toLowerCase());
+        if (!entry) return pm;
+        return {
+          ...pm,
+          username: entry.nick, // case correction
+          realname: entry.realname ?? pm.realname,
+          account: entry.account ?? pm.account,
+          isOnline: true,
+          isAway: entry.isAway ?? pm.isAway,
+          isBot: (pm.isBot || entry.isBot) ?? pm.isBot,
+          isIrcOp: entry.isIrcOp ?? pm.isIrcOp,
+        };
+      });
+
+      return {
+        ...s,
+        channels: updatedChannels,
+        privateChats: updatedPrivateChats,
+      };
+    });
+
+    return { servers: updatedServers };
+  });
+}
+
+function mergeUser(prev: User, entry: BufferedWhoEntry): User {
+  return {
+    ...prev,
+    username: entry.nick, // server-authoritative casing
+    hostname: entry.host ?? prev.hostname,
+    realname: entry.realname ?? prev.realname,
+    account: entry.account ?? prev.account,
+    isOnline: true,
+    isAway: entry.isAway ?? prev.isAway,
+    isBot: entry.isBot ?? prev.isBot,
+    isIrcOp: entry.isIrcOp ?? prev.isIrcOp,
+    status: entry.status ?? prev.status,
+  };
+}
+
+function entryToUser(entry: BufferedWhoEntry): User {
+  return {
+    id: entry.nick,
+    username: entry.nick,
+    hostname: entry.host,
+    realname: entry.realname,
+    avatar: undefined,
+    isOnline: true,
+    isAway: !!entry.isAway,
+    isBot: !!entry.isBot,
+    isIrcOp: !!entry.isIrcOp,
+    status: entry.status,
+    account: entry.account ?? undefined,
+    metadata: {},
+  };
+}
+
+export function bufferWhoReply(
+  store: StoreApi<AppState>,
+  serverId: string,
+  channel: string,
+  entry: BufferedWhoEntry,
+): void {
+  const k = key(serverId, channel);
+  const existing = buckets.get(k);
+  const bucket: ChannelBucket = existing ?? {
+    serverId,
+    channel,
+    byNick: new Map(),
+    idleTimer: undefined,
+    ceilingTimer: undefined,
+  };
+  if (!existing) {
+    buckets.set(k, bucket);
+    bucket.ceilingTimer = setTimeout(
+      () => applyBucket(store, bucket),
+      FLUSH_MAX_MS,
+    );
+  }
+  // Last-write-wins per nick within a burst (the most recent WHO line
+  // for a given user is the authoritative one).
+  bucket.byNick.set(entry.nick.toLowerCase(), entry);
+  if (bucket.idleTimer) clearTimeout(bucket.idleTimer);
+  bucket.idleTimer = setTimeout(
+    () => applyBucket(store, bucket),
+    FLUSH_IDLE_MS,
+  );
+}
+
+export function flushWhoReplies(
+  store: StoreApi<AppState>,
+  serverId: string,
+  channel: string,
+): void {
+  const bucket = buckets.get(key(serverId, channel));
+  if (bucket) applyBucket(store, bucket);
+}
+
+// Test-only helpers.
+export function _resetWhoReplyBatcher(): void {
+  for (const b of buckets.values()) {
+    if (b.idleTimer) clearTimeout(b.idleTimer);
+    if (b.ceilingTimer) clearTimeout(b.ceilingTimer);
+  }
+  buckets.clear();
+}
+
+export function _peekWhoReplyBatcher(serverId: string, channel: string) {
+  return buckets.get(key(serverId, channel));
+}

--- a/tests/store/join.test.ts
+++ b/tests/store/join.test.ts
@@ -1,8 +1,9 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import ircClient from "../../src/lib/ircClient";
 import type { AppState } from "../../src/store";
 import useStore from "../../src/store";
 import { readyProcessedServers } from "../../src/store/handlers/connection";
+import * as storage from "../../src/store/localStorage";
 import type { Channel } from "../../src/types";
 
 function makeChannel(overrides: Partial<Channel> = {}): Channel {
@@ -46,19 +47,20 @@ const AVATAR_META = {
   avatar: { value: "http://cdn.example.com/avatar.png", visibility: "public" },
 };
 
-// storage.metadata.load() reads localStorage.getItem("serverMetadata")
-function mockLocalStorageMeta(data: Record<string, unknown>) {
-  vi.mocked(window.localStorage.getItem).mockReturnValue(JSON.stringify(data));
+// metadata is now an in-memory module cache; seed it via storage.metadata.save().
+// biome-ignore lint/suspicious/noExplicitAny: test helper accepts loose shape
+function seedMetadata(data: Record<string, any>) {
+  storage.metadata.save(data);
 }
 
 describe("live JOIN — metadata restoration", () => {
   beforeEach(() => {
     setupServer();
-    vi.mocked(window.localStorage.getItem).mockReturnValue("{}");
+    storage.metadata.save({});
   });
 
   it("attaches localStorage metadata to user on live join", () => {
-    mockLocalStorageMeta({ "srv-1": { bob: AVATAR_META } });
+    seedMetadata({ "srv-1": { bob: AVATAR_META } });
 
     ircClient.triggerEvent("JOIN", {
       serverId: "srv-1",

--- a/tests/store/whoReplyBatcher.test.ts
+++ b/tests/store/whoReplyBatcher.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { StoreApi } from "zustand";
+import {
+  _peekWhoReplyBatcher,
+  _resetWhoReplyBatcher,
+  bufferWhoReply,
+  flushWhoReplies,
+} from "../../src/store/whoReplyBatcher";
+
+function makeMockStore() {
+  const setCalls: unknown[] = [];
+  let state: {
+    servers: Array<{
+      id: string;
+      channels: Array<{
+        name: string;
+        users: Array<{
+          id: string;
+          username: string;
+          metadata: Record<string, unknown>;
+          [k: string]: unknown;
+        }>;
+      }>;
+      privateChats?: Array<{
+        username: string;
+        [k: string]: unknown;
+      }>;
+    }>;
+  } = {
+    servers: [
+      {
+        id: "s1",
+        channels: [
+          { name: "#room", users: [] },
+          { name: "#other", users: [] },
+        ],
+        privateChats: [],
+      },
+    ],
+  };
+  return {
+    setState: vi.fn((updater: unknown) => {
+      setCalls.push(updater);
+      if (typeof updater === "function") {
+        const patch = (updater as (s: typeof state) => Partial<typeof state>)(
+          state,
+        );
+        state = { ...state, ...patch };
+      }
+    }),
+    getState: () => state,
+    // biome-ignore lint/suspicious/noExplicitAny: minimal mock
+    subscribe: vi.fn() as any,
+    setCalls,
+    snapshot: () => state,
+    // biome-ignore lint/suspicious/noExplicitAny: minimal mock
+  } as unknown as StoreApi<any> & {
+    setCalls: unknown[];
+    snapshot: () => typeof state;
+  };
+}
+
+describe("whoReplyBatcher", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    _resetWhoReplyBatcher();
+  });
+
+  afterEach(() => {
+    _resetWhoReplyBatcher();
+    vi.useRealTimers();
+  });
+
+  test("coalesces N WHO replies into a single setState after idle", () => {
+    const store = makeMockStore();
+    for (let i = 0; i < 50; i++) {
+      bufferWhoReply(store, "s1", "#room", {
+        nick: `user${i}`,
+        host: "h.example",
+        realname: `Real ${i}`,
+        status: "",
+      });
+    }
+    expect(store.setState).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(59);
+    expect(store.setState).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(2);
+    expect(store.setState).toHaveBeenCalledTimes(1);
+    const finalUsers = store.snapshot().servers[0].channels[0].users;
+    expect(finalUsers).toHaveLength(50);
+    expect(finalUsers[0].username).toBe("user0");
+    expect(finalUsers[49].username).toBe("user49");
+  });
+
+  test("last-write-wins per nick within a single burst", () => {
+    const store = makeMockStore();
+    bufferWhoReply(store, "s1", "#room", {
+      nick: "alice",
+      realname: "first",
+      host: "first.host",
+    });
+    bufferWhoReply(store, "s1", "#room", {
+      nick: "alice",
+      realname: "second",
+      host: "second.host",
+    });
+    vi.advanceTimersByTime(70);
+    const u = store.snapshot().servers[0].channels[0].users[0];
+    expect(u.realname).toBe("second");
+    expect(u.hostname).toBe("second.host");
+  });
+
+  test("explicit flushWhoReplies bypasses the idle wait (WHO_END path)", () => {
+    const store = makeMockStore();
+    bufferWhoReply(store, "s1", "#room", { nick: "bob" });
+    expect(store.setState).not.toHaveBeenCalled();
+    flushWhoReplies(store, "s1", "#room");
+    expect(store.setState).toHaveBeenCalledTimes(1);
+    expect(_peekWhoReplyBatcher("s1", "#room")).toBeUndefined();
+  });
+
+  test("a trickling WHO still flushes via the ceiling timer", () => {
+    const store = makeMockStore();
+    // Push a reply, then keep re-arming idle just under 60ms apart so
+    // the idle timer NEVER fires. Ceiling at 1000ms should still flush.
+    for (let i = 0; i < 30; i++) {
+      bufferWhoReply(store, "s1", "#room", { nick: `slow${i}` });
+      vi.advanceTimersByTime(30);
+    }
+    expect(store.setState).not.toHaveBeenCalled();
+    // One more push to make the elapsed time exceed FLUSH_MAX_MS overall
+    vi.advanceTimersByTime(200);
+    expect(store.setState).toHaveBeenCalledTimes(1);
+    const users = store.snapshot().servers[0].channels[0].users;
+    expect(users).toHaveLength(30);
+  });
+
+  test("merges into existing users rather than appending duplicates", () => {
+    const store = makeMockStore();
+    // Seed: pretend alice was already in the user list from NAMES.
+    const s = store.snapshot();
+    s.servers[0].channels[0].users.push({
+      id: "alice",
+      username: "alice",
+      metadata: {},
+      realname: undefined,
+      hostname: undefined,
+    });
+    bufferWhoReply(store, "s1", "#room", {
+      nick: "alice",
+      host: "h.example",
+      realname: "Alice Cooper",
+      isIrcOp: true,
+    });
+    vi.advanceTimersByTime(70);
+    const users = store.snapshot().servers[0].channels[0].users;
+    expect(users).toHaveLength(1);
+    expect(users[0].realname).toBe("Alice Cooper");
+    expect(users[0].isIrcOp).toBe(true);
+    expect(users[0].hostname).toBe("h.example");
+  });
+
+  test("buckets are scoped per (serverId, channel)", () => {
+    const store = makeMockStore();
+    bufferWhoReply(store, "s1", "#room", { nick: "alice" });
+    bufferWhoReply(store, "s1", "#other", { nick: "bob" });
+    vi.advanceTimersByTime(70);
+    // Two distinct setState calls (one per bucket), each in a separate
+    // timer tick.
+    expect(store.setState).toHaveBeenCalledTimes(2);
+    const snap = store.snapshot();
+    expect(snap.servers[0].channels[0].users[0].username).toBe("alice");
+    expect(snap.servers[0].channels[1].users[0].username).toBe("bob");
+  });
+});


### PR DESCRIPTION
**Stacked on top of PR #212** — both deal with the same scenario (a 500-user channel) but at different layers. #212 stops the recvq disconnect; this one stops the nicklist trickling in one user at a time.

## Symptom on the 500-bot test channel

After joining \`#cattest\` (with #212's lazy fetch in place), the member list still ticked in one nick at a time, taking visibly long to fully render. Profile showed MemberList re-rendering ~500 times.

## Cause

Each \`352\` (\`RPL_WHOREPLY\`) and \`354\` (WHOX \`RPL_WHOSPCRPL\`) was running a full \`store.setState\` that mapped over every server, every channel, every user, and every private chat — **once per nick**. With 500 users in the channel that's 500 React re-renders of MemberList in a few hundred ms, plus a fresh \`IntersectionObserver\` round per render scheduling another lazy fetch burst.

## Fix

[\`src/store/whoReplyBatcher.ts\`](src/store/whoReplyBatcher.ts) — a small per-\`(serverId, channel)\` buffer with:

- **Idle flush**: 60 ms after the last reply. Common case is a burst of 500 replies in <200 ms; we render once at the tail.
- **Ceiling flush**: 1000 ms hard limit so a slowly trickling WHO from a degraded link still produces visible progress.
- **Explicit flush on \`WHO_END\`**: the channel renders the moment the server says it's done — no need to wait out the idle timer.
- **Last-write-wins per nick** within a burst.

\`WHO_REPLY\` (channel path) and \`WHOX_REPLY\` (channel path) both push into the buffer instead of running \`setState\`. The PM-only fallbacks (channel === \`\"*\"\` or no channel) stay inline since they're single lines, not part of a burst.

## Test plan

- [x] \`npm run format\`, \`npm run check\`, \`npm run test\` (795 pass, 1 skipped), \`npm run build\` clean
- [x] New \`tests/store/whoReplyBatcher.test.ts\`: 6 tests covering idle flush, last-write-wins, explicit flush, ceiling fallback, merge-into-existing, and per-channel bucket scoping