### PR TITLE
fix(avatar-upload): use EXTJWT instead of draft/authtoken

### DIFF
--- a/src/components/ui/AvatarUpload.tsx
+++ b/src/components/ui/AvatarUpload.tsx
@@ -2,7 +2,6 @@ import { t } from "@lingui/core/macro";
 import type React from "react";
 import { useRef, useState } from "react";
 import { FaSpinner, FaTimes, FaUpload } from "react-icons/fa";
-import { waitForAuthToken } from "../../lib/authToken";
 import ircClient from "../../lib/ircClient";
 import useStore from "../../store";
 import { TextInput } from "./TextInput";
@@ -68,34 +67,30 @@ const AvatarUpload: React.FC<AvatarUploadProps> = ({
     setUploadError(null);
 
     try {
-      // draft/authtoken: clear any cached token and ask for a fresh one.
-      // The server scopes per-token to (account, channel) so we always
-      // re-mint when target changes.
+      // The hosted-backend's /upload/avatar/* endpoints validate an
+      // *EXTJWT* token (same as /upload), not a draft/authtoken one.
+      // We previously asked for draft/authtoken which obbyircd doesn't
+      // have a service block for, so the server timed out and the
+      // caller saw "did not return a filehost token". Fetch an EXTJWT
+      // for the filehost service instead, mirroring ChatArea's image-
+      // upload path.
       useStore.setState((state) => ({
         servers: state.servers.map((server) =>
-          server.id === serverId
-            ? {
-                ...server,
-                authToken: undefined,
-                authTokenUrl: undefined,
-                authTokenService: undefined,
-              }
-            : server,
+          server.id === serverId ? { ...server, jwtToken: undefined } : server,
         ),
       }));
-
-      const scope = channelName ? `channel:${channelName}` : undefined;
-      ircClient.requestToken(serverId, "filehost", scope);
-      const authToken = await waitForAuthToken(serverId, "filehost");
-      if (!authToken) {
-        throw new Error(
-          "draft/authtoken: server did not return a filehost token",
-        );
-      }
+      ircClient.requestExtJwt(serverId, "*", "filehost");
+      // EXTJWT replies populate `server.jwtToken` asynchronously via the
+      // store handler; poll briefly the way ChatArea's uploader does.
+      await new Promise((resolve) => setTimeout(resolve, 1000));
       const refreshed = useStore
         .getState()
         .servers.find((s) => s.id === serverId);
-      const baseUrl = refreshed?.authTokenUrl || refreshed?.filehost || "";
+      const jwtToken = refreshed?.jwtToken;
+      if (!jwtToken) {
+        throw new Error("EXTJWT: server did not return a filehost token");
+      }
+      const baseUrl = refreshed?.filehost || filehostUrl;
 
       const formData = new FormData();
       formData.append("image", file);
@@ -109,7 +104,7 @@ const AvatarUpload: React.FC<AvatarUploadProps> = ({
       const response = await fetch(uploadUrl, {
         method: "POST",
         headers: {
-          Authorization: `Bearer ${authToken}`,
+          Authorization: `Bearer ${jwtToken}`,
         },
         body: formData,
       });


### PR DESCRIPTION
## Summary

Avatar upload was failing with `draft/authtoken: server did not return a filehost token` because the uploader sent `TOKEN GENERATE filehost` (the new draft/authtoken protocol) and waited up to 5s for a reply that never came.

## Root cause

Two compounding issues:

1. **obbyircd has no `authtoken { service \"filehost\" {...}; }` config block** — only the legacy `extjwt { service \"filehost\" {...}; }` block. So `TOKEN GENERATE filehost` is answered with `FAIL TOKEN UNKNOWN_SERVICE filehost`, the client's `waitForAuthToken` listener never fires, and we time out.
2. **hosted-backend's `/upload/avatar/*` endpoints validate a JWT via `AuthMiddleware`** — meaning even if a draft/authtoken bearer had come through, it would have been rejected because it isn't a JWT.

The chat-area image uploader doesn't hit either of these because it uses `EXTJWT * filehost` instead. This PR mirrors that path for avatar uploads.

## Fix

`AvatarUpload.tsx`:
- Replace `requestToken(\"filehost\", scope)` + `waitForAuthToken` with `requestExtJwt(\"*\", \"filehost\")` + the same brief poll for `server.jwtToken` that ChatArea uses.
- Use the JWT as the bearer when POSTing to `/upload/avatar/user` or `/upload/avatar/channel/<chan>`.
- Drop the now-unused `waitForAuthToken` import.

## Test plan

- [x] tsc clean
- [x] vite build clean
- [ ] Manual: upload a user avatar from User Settings against obby.t3ks.com → JWT comes back, hosted-backend `AuthMiddleware` accepts it, file lands at `/uploads/avatar_user_<account>_<ts>.<ext>`
- [ ] Manual: upload a channel avatar (channel ops only) → endpoint differs but auth flow is identical

(If someone wants to flip the whole thing to draft/authtoken later, the work is bigger: add an `authtoken { service \"filehost\" { url ...; require-account yes; }; }` block to obbyircd.conf, then teach hosted-backend's `AuthMiddleware` to optionally call `TOKEN VALIDATE` against obbyircd's RPC. Out of scope for this PR.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated avatar upload authentication mechanism to use an enhanced token system for improved security and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ObsidianIRC/ObsidianIRC/pull/218)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->