### PR TITLE
feat: Nix flake with devShell, package build, and Home Manager module

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+# Nix flake dev shell (same as `nix develop`). Requires Nix with flakes enabled.
+# First time in this clone: direnv allow
+# Optional faster reloads: https://github.com/nix-community/nix-direnv
+use flake

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -29,6 +29,19 @@ jobs:
     - name: Test
       run: npm run test
 
+  nix-linux:
+    name: Nix package (Linux x86_64)
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - name: Build obsidianirc
+        run: nix flake check && nix build .#obsidianirc --no-link --print-build-logs
+
   i18n:
     name: i18n Catalog Check
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,13 @@
 # misc
 .DS_Store
 .env*
+!.envrc
+
+# direnv + nix-direnv cache (regenerated on `direnv allow` / entering the directory)
+.direnv/
+
+# Nix build output symlink
+/result
 
 npm-debug.log*
 yarn-debug.log*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ npm run format; npm run fix:unsafe; npm run test; npm run build
 
 ## Tool versions
 
-- **JavaScript:** **Node ≥22** ([`package.json` `engines`](package.json)); **`npm ci`** from the repo root for reproducible installs.
+- **JavaScript:** **Node ≥22** ([`package.json` `engines`](package.json)); **`npm install`** from the repo root.
 - **Rust (Tauri):** [`rust-toolchain.toml`](rust-toolchain.toml) — **stable** + **rustfmt**/**clippy**; MSRV in [src-tauri/Cargo.toml](src-tauri/Cargo.toml).
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,23 @@ npm run format; npm run fix:unsafe; npm run test; npm run build
 
 ---
 
+## Tool versions
+
+- **JavaScript:** **Node ≥22** ([`package.json` `engines`](package.json)); **`npm ci`** from the repo root for reproducible installs.
+- **Rust (Tauri):** [`rust-toolchain.toml`](rust-toolchain.toml) — **stable** + **rustfmt**/**clippy**; MSRV in [src-tauri/Cargo.toml](src-tauri/Cargo.toml).
+
+---
+
+## Nix (this flake)
+
+- **`nix develop`** — Node 22, Tauri Linux libs (WebKitGTK 4.1, GTK 3, OpenSSL, Ayatana appindicator, …), **rustup** from `rust-toolchain.toml`. **ObsidianIRC’s flake only declares `devShells` + `packages` for `x86_64-linux` / `aarch64-linux`** (you can still install Nix elsewhere; there is no matching devShell for Darwin/Windows in-tree today). **macOS/Windows** → extend [flake.nix](flake.nix) or use host **Node** + **rustup** (same `rust-toolchain.toml`).
+- **direnv:** [.envrc](.envrc) **`use flake`** after **`direnv allow`**; optional faster reloads via [nix-direnv](https://github.com/nix-community/nix-direnv) (**.direnv/** gitignored). Hook: [direnv shell integration](https://direnv.net/docs/hook.html).
+- **`nix build .#obsidianirc`** (**`x86_64`** / **`aarch64`**) — **`cargo-tauri.hook`**. Bump **`npmDeps`** in [nix/obsidianirc.nix](nix/obsidianirc.nix) when **`package-lock.json`** changes and Nix errors.
+- **Wayland / WebKit quirks** — try X11 or pin **`nixpkgs`** (NixOS/Tauri discussions).
+- **Home Manager:** **`outputs.homeManagerModules.obsidianirc`** and **`outputs.homeModules.obsidianirc`** (same attr). Follow **[Home Manager manual — Flakes](https://nix-community.github.io/home-manager/index.xhtml#ch-nix-flakes)**: **`inputs.home-manager.inputs.nixpkgs.follows`** in consumer flakes, **`useGlobalPkgs`**, **`useUserPackages`**, **`extraSpecialArgs`**. **BUILD.md** has overlay/`pkgs` caveats for **`programs.obsidianirc`** / **`viteBuildEnv`**.
+
+---
+
 ## Project Layout
 
 ```
@@ -223,14 +240,16 @@ All user-visible text **must** be wrapped with LinguiJS macros so it can be tran
 
 ### Which tool to use
 
-| String location | Macro | Import |
-|-----------------|-------|--------|
-| JSX text children (`<button>`, `<span>`, `<p>`, headings) | `<Trans>…</Trans>` | `import { Trans } from "@lingui/macro"` |
-| JSX props: `placeholder=`, `aria-label=`, `title=` | `` t`…` `` via `useLingui` | `import { useLingui } from "@lingui/macro"` then `const { t } = useLingui()` inside the component |
-| Simple `t` outside JSX (inside a render function) | `` t`…` `` | `import { t } from "@lingui/macro"` |
-| Variables/interpolation | `` t`Hello ${name}` `` | same — placeholders become `{0}` in the PO file |
-| Non-React `.ts` files (store handlers, event callbacks) | `` t`…` `` | `import { t } from "@lingui/macro"` — safe inside callbacks that fire after `i18n.activate()` |
-| Module-level constants | **Do not use** `t` at module scope | `t` evaluates before `i18n.activate()` runs. Move the string inside the function body. |
+
+| String location                                           | Macro                              | Import                                                                                            |
+| --------------------------------------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------- |
+| JSX text children (`<button>`, `<span>`, `<p>`, headings) | `<Trans>…</Trans>`                 | `import { Trans } from "@lingui/macro"`                                                           |
+| JSX props: `placeholder=`, `aria-label=`, `title=`        | `t`…`` via `useLingui`             | `import { useLingui } from "@lingui/macro"` then `const { t } = useLingui()` inside the component |
+| Simple `t` outside JSX (inside a render function)         | `t`…``                             | `import { t } from "@lingui/macro"`                                                               |
+| Variables/interpolation                                   | `t`Hello ${name}``                 | same — placeholders become `{0}` in the PO file                                                   |
+| Non-React `.ts` files (store handlers, event callbacks)   | `t`…``                             | `import { t } from "@lingui/macro"` — safe inside callbacks that fire after `i18n.activate()`     |
+| Module-level constants                                    | **Do not use** `t` at module scope | `t` evaluates before `i18n.activate()` runs. Move the string inside the function body.            |
+
 
 ### Correct patterns
 
@@ -303,6 +322,7 @@ Write the complete translated file back.
 ### CI checks
 
 The `i18n` job in `.github/workflows/workflow.yaml`:
+
 - **Fails** if source has `t`/`Trans` strings not yet extracted into `en/messages.po`.
 - **Fails** if compiled `.mjs` catalogs are stale relative to their `.po` files.
 - **Reports** (informational, non-blocking) how many strings are translated per locale in the job summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,14 +26,11 @@ npm run format; npm run fix:unsafe; npm run test; npm run build
 
 ---
 
-## Nix (this flake)
+## Nix
 
-- **`nix develop`** — Node 22, Tauri Linux libs (WebKitGTK 4.1, GTK 3, OpenSSL, Ayatana appindicator, …), **rustup** from `rust-toolchain.toml`. **ObsidianIRC’s flake only declares `devShells` + `packages` for `x86_64-linux` / `aarch64-linux`** (you can still install Nix elsewhere; there is no matching devShell for Darwin/Windows in-tree today). **macOS/Windows** → extend [flake.nix](flake.nix) or use host **Node** + **rustup** (same `rust-toolchain.toml`).
-- **direnv:** [.envrc](.envrc) **`use flake`** after **`direnv allow`**; optional faster reloads via [nix-direnv](https://github.com/nix-community/nix-direnv) (**.direnv/** gitignored). Hook: [direnv shell integration](https://direnv.net/docs/hook.html).
-- **`nix build .#obsidianirc`** (**`x86_64`** / **`aarch64`**) — **`cargo-tauri.hook`**. Bump **`npmDeps`** in [nix/obsidianirc.nix](nix/obsidianirc.nix) when **`package-lock.json`** changes and Nix errors.
-- **Wayland / WebKit quirks** — try X11 or pin **`nixpkgs`** (NixOS/Tauri discussions).
-- **Home Manager:** **`outputs.homeManagerModules.obsidianirc`** and **`outputs.homeModules.obsidianirc`** (same attr). Follow **[Home Manager manual — Flakes](https://nix-community.github.io/home-manager/index.xhtml#ch-nix-flakes)**: **`inputs.home-manager.inputs.nixpkgs.follows`** in consumer flakes, **`useGlobalPkgs`**, **`useUserPackages`**, **`extraSpecialArgs`**. **BUILD.md** has overlay/`pkgs` caveats for **`programs.obsidianirc`** / **`viteBuildEnv`**.
-
+- **`nix develop`** — full dev environment (Node 22 + Tauri Linux deps + rustup). Linux only (`x86_64`/`aarch64`).
+- **`nix build .#obsidianirc`** — produces `result/bin/ObsidianIRC`. Bump `npmDeps` in [nix/obsidianirc.nix](nix/obsidianirc.nix) when `package-lock.json` changes.
+- Details: [BUILD.md — Nix (flake)](BUILD.md#nix-flake)
 ---
 
 ## Project Layout

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -219,16 +219,34 @@ npm run commit-hook-install  # Install git hooks
 **File:** `Dockerfile`
 
 Multi-stage build:
-1. **Builder stage** - Node.js 23 Alpine, npm ci, build
-2. **Runtime stage** - Nginx Alpine serving static files
+1. **Builder stage** — `node:22-alpine`, `npm ci`, Vite production build (`VITE_*` `ARG`s → `ENV`, see **`Dockerfile`**)
+2. **Runtime stage** — Nginx Alpine serving static files
 
-**Environment Variables:**
+**Environment Variables (builder):**
+
+All names below are optional `Dockerfile` **`ARG`**s (forwarded into `npm run build`). The Nix derivation accepts the same prefixes via **`viteBuildEnv`** (see **`nix/obsidianirc.nix`**).
+
 ```bash
-VITE_DEFAULT_IRC_SERVER      # Default server URL
-VITE_DEFAULT_IRC_SERVER_NAME # Server display name
-VITE_DEFAULT_IRC_CHANNELS    # Auto-join channels
-VITE_HIDE_SERVER_LIST        # Hide server selection
-VITE_TRUSTED_MEDIA_URLS      # Comma-separated list of trusted media URLs
+# vite.config.ts `define`
+VITE_DEFAULT_IRC_SERVER
+VITE_DEFAULT_IRC_SERVER_NAME
+VITE_DEFAULT_IRC_CHANNELS
+VITE_HIDE_SERVER_LIST
+VITE_TRUSTED_MEDIA_URLS
+VITE_DEFAULT_OAUTH_PROVIDER_LABEL
+VITE_DEFAULT_OAUTH_ISSUER
+VITE_DEFAULT_OAUTH_CLIENT_ID
+VITE_DEFAULT_OAUTH_SCOPES
+VITE_DEFAULT_OAUTH_REDIRECT_URI
+VITE_DEFAULT_OAUTH_TOKEN_KIND
+VITE_DEFAULT_OAUTH_SERVER_PROVIDER
+VITE_DEFAULT_OAUTH_AUTHORIZE_URL
+VITE_DEFAULT_OAUTH_TOKEN_URL
+VITE_BACKEND_URL
+
+# Client embeds (`import.meta.env`; GIF widgets)
+VITE_GIPHY_API_KEY
+VITE_TENOR_API_KEY
 ```
 
 ### GitHub Actions CI/CD

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,8 +1,10 @@
 # Compile ObsidianIRC
+
 This covers instructions for how to manually build ObsidianIRC from source for different platforms. If you are willing
 to simply install it, maybe take a look at [Install instructions](INSTALL.md) first.
 
 ## Clone Repo
+
 ```sh
 cd ~
 git clone https://github.com/ObsidianIRC/ObsidianIRC
@@ -11,13 +13,16 @@ npm install
 ```
 
 ### Web
+
 ```sh
 npm run build
 cp -R dist/* /var/www/html/
 ```
 
 #### Building for a specific server
-You can build the frontend by setting the following environment variables before running the `npm build` command.
+
+You can build the frontend by setting the following environment variables before running `npm run build`.
+
 ```sh
 # Required server URL
 VITE_DEFAULT_IRC_SERVER=ws://localhost:8097
@@ -52,6 +57,12 @@ VITE_DEFAULT_OAUTH_SERVER_PROVIDER="github"
 # publish /.well-known/openid-configuration.
 VITE_DEFAULT_OAUTH_AUTHORIZE_URL="https://github.com/login/oauth/authorize"
 VITE_DEFAULT_OAUTH_TOKEN_URL="https://github.com/login/oauth/access_token"
+
+# Optional: baked via vite `define` as `__BACKEND_URL__` (see vite.config.ts); available but not yet referenced in source.
+VITE_BACKEND_URL=http://localhost:8080
+# GIF search/embeds (`import.meta.env` in `GifSelector` / Tenor previews in `MediaPreview`)
+VITE_GIPHY_API_KEY=
+VITE_TENOR_API_KEY=
 ```
 
 #### Provider quick-reference
@@ -99,15 +110,17 @@ oauth-provider "github" {
 };
 ```
 
-
 ### Docker
+
 ```sh
 docker build -t obsidianirc .
 docker run -p 80:80 obsidianirc
 ```
 
 #### Building Docker with custom configuration
-You can pass build arguments to customize the IRC server settings:
+
+You can pass build arguments to customize the IRC server settings. The image forwards the same **`VITE_*`** names as **`vite.config.ts`** (IRC, OAuth lock-mode, `VITE_BACKEND_URL`) plus optional **`VITE_GIPHY_API_KEY`** / **`VITE_TENOR_API_KEY`** for GIF search/embeds (`Dockerfile` lists every supported `ARG`).
+
 ```sh
 docker build \
   --build-arg VITE_DEFAULT_IRC_SERVER=ws://your-server:port \
@@ -118,21 +131,21 @@ docker build \
   --build-arg VITE_DEFAULT_OAUTH_PROVIDER_LABEL="Logto" \
   --build-arg VITE_DEFAULT_OAUTH_ISSUER="https://my-tenant.logto.app/oidc" \
   --build-arg VITE_DEFAULT_OAUTH_CLIENT_ID="m0obbyircd1234" \
+  --build-arg VITE_BACKEND_URL=https://api.example.net \
+  --build-arg VITE_TENOR_API_KEY=your-tenor-key \
   -t obsidianirc .
 ```
 
-### MACOS
-```sh
-npm run tauri build -- --bundles dmg
-```
-
 ### LINUX
+
+#### npm / Tauri CLI
+
 ```sh
 npm run tauri build -- --bundles appimage
 ```
 
-
 For distribution packages:
+
 ```sh
 # Build .deb for Debian/Ubuntu
 npm run tauri build -- --bundles deb
@@ -144,27 +157,53 @@ npm run tauri build -- --bundles rpm
 npm run tauri build -- --bundles appimage
 ```
 
-### WINDOWS
+#### Nix (flake)
+
+[Nix](https://nixos.org/download/) with [flakes](https://wiki.nixos.org/wiki/Flakes) enabled. **`devShells`** and **`packages.obsidianirc`** exist only for **`x86_64-linux`** and **`aarch64-linux`**; on macOS/Windows use a normal host Node + Rust (rustup / rust-toolchain.toml) toolchain ([AGENTS.md](AGENTS.md)). Web and Docker builds are outside this flake.
+
 ```sh
-npm run build -- --bundles nsis
+nix develop              # Node 22 + Tauri Linux deps + rustup
+nix build .#obsidianirc  # → result/bin/ObsidianIRC
+```
+
+**direnv:** [.envrc](.envrc) uses `use flake` — [CONTRIBUTING.md](CONTRIBUTING.md).
+
+- **Home Manager:** `outputs.homeManagerModules.obsidianirc` and **`outputs.homeModules.obsidianirc`** are the **same module** (`programs.obsidianirc.*`; pick either spelling — see **[Home Manager manual — Flakes](https://nix-community.github.io/home-manager/index.xhtml#ch-nix-flakes)**). **`home.stateVersion` stays on the value from your original HM install.** Import this module alongside `home-manager.nixosModules.home-manager` on **NixOS**. Follow the manual’s recommendation: **`home-manager.useGlobalPkgs = true`**, **`home-manager.useUserPackages = true`**, **`home-manager.extraSpecialArgs = { inherit inputs; };`** when referencing flake inputs from `home.nix`. Prefer **`inputs.home-manager.inputs.nixpkgs.follows = "nixpkgs"`** in your consumer flake. With **`useGlobalPkgs`**, merge [nix/overlay.nix](nix/overlay.nix) **where system `pkgs` is built** (not only `nixpkgs.overlays` under `home-manager.users.<name>`). Options and MIME notes: [nix/hm-module.nix](nix/hm-module.nix). Autostart needs **`xdg.enable = true`** (asserted).
+- **Checks:** `nix flake check` evaluates the HM module with a stub package (not a full Tauri build). One-shot: `nix build .#checks.x86_64-linux.home-manager-module` (or `aarch64-linux`).
+- **When things break:** if `package-lock.json` changes, update `npmDeps` in [nix/obsidianirc.nix](nix/obsidianirc.nix). After nixpkgs bumps, keep GTK/WebKit-related inputs in [flake.nix](flake.nix) and [nix/obsidianirc.nix](nix/obsidianirc.nix) aligned.
+
+### macOS
+
+```sh
+npm run tauri build -- --bundles dmg
+```
+
+### WINDOWS
+
+```sh
+npm run tauri build -- --bundles nsis
 ```
 
 ### Android
+
 ```sh
 npm run tauri android build -- --apk
 ```
 
 ### IOS
+
 First open xcode with the tauri ws config server running:
+
 ```sh
 npm run tauri ios build -- --open
 ```
 
 Set the signing team in the xcode project settings and then build the app:
+
 ```sh
 npm run tauri ios build
 ```
 
 ## Tauri
-Follow the Tauri docs for more info on native builds https://tauri.app/distribute/
 
+Follow the Tauri docs for more info on native builds [https://tauri.app/distribute/](https://tauri.app/distribute/)

--- a/BUILD.md
+++ b/BUILD.md
@@ -159,19 +159,16 @@ npm run tauri build -- --bundles appimage
 
 #### Nix (flake)
 
-[Nix](https://nixos.org/download/) with [flakes](https://wiki.nixos.org/wiki/Flakes) enabled. **`devShells`** and **`packages.obsidianirc`** exist only for **`x86_64-linux`** and **`aarch64-linux`**; on macOS/Windows use a normal host Node + Rust (rustup / rust-toolchain.toml) toolchain ([AGENTS.md](AGENTS.md)). Web and Docker builds are outside this flake.
+[Nix](https://nixos.org/download/) with [flakes](https://wiki.nixos.org/wiki/Flakes) enabled. Linux only (`x86_64-linux`, `aarch64-linux`).
 
 ```sh
 nix develop              # Node 22 + Tauri Linux deps + rustup
 nix build .#obsidianirc  # → result/bin/ObsidianIRC
 ```
 
-**direnv:** [.envrc](.envrc) uses `use flake` — [CONTRIBUTING.md](CONTRIBUTING.md).
-
-- **Home Manager:** `outputs.homeManagerModules.obsidianirc` and **`outputs.homeModules.obsidianirc`** are the **same module** (`programs.obsidianirc.*`; pick either spelling — see **[Home Manager manual — Flakes](https://nix-community.github.io/home-manager/index.xhtml#ch-nix-flakes)**). **`home.stateVersion` stays on the value from your original HM install.** Import this module alongside `home-manager.nixosModules.home-manager` on **NixOS**. Follow the manual’s recommendation: **`home-manager.useGlobalPkgs = true`**, **`home-manager.useUserPackages = true`**, **`home-manager.extraSpecialArgs = { inherit inputs; };`** when referencing flake inputs from `home.nix`. Prefer **`inputs.home-manager.inputs.nixpkgs.follows = "nixpkgs"`** in your consumer flake. With **`useGlobalPkgs`**, merge [nix/overlay.nix](nix/overlay.nix) **where system `pkgs` is built** (not only `nixpkgs.overlays` under `home-manager.users.<name>`). Options and MIME notes: [nix/hm-module.nix](nix/hm-module.nix). Autostart needs **`xdg.enable = true`** (asserted).
-- **Checks:** `nix flake check` evaluates the HM module with a stub package (not a full Tauri build). One-shot: `nix build .#checks.x86_64-linux.home-manager-module` (or `aarch64-linux`).
-- **When things break:** if `package-lock.json` changes, update `npmDeps` in [nix/obsidianirc.nix](nix/obsidianirc.nix). After nixpkgs bumps, keep GTK/WebKit-related inputs in [flake.nix](flake.nix) and [nix/obsidianirc.nix](nix/obsidianirc.nix) aligned.
-
+- **direnv:** `direnv allow` activates [.envrc](.envrc) (`use flake`).
+- **Home Manager:** `programs.obsidianirc` module — see [nix/hm-module.nix](nix/hm-module.nix) for options and usage.
+- **Maintenance:** bump `npmDeps` in [nix/obsidianirc.nix](nix/obsidianirc.nix) when `package-lock.json` changes.
 ### macOS
 
 ```sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing
 
 ## Clone and setup the repository
+
 ```sh
 git clone https://github.com/ObsidianIRC/ObsidianIRC
 cd ObsidianIRC
@@ -8,22 +9,35 @@ npm install
 npm run dev  # Start the development server
 ```
 
+Use **`npm run …`** for scripts regardless of which toolchain you choose below.
+
+**Optional — Nix** (Nix installs on other OSes too — [non-NixOS Linux](https://nixos.org/download/) is common): **`nix develop`** from this repo works only where the **ObsidianIRC** flake exposes a **devShell**, i.e. **`x86_64-linux`** / **`aarch64-linux`** today (**`nix build .#obsidianirc`** same). On **macOS or Windows** extend `flake.nix` or install **Node ≥22** and **Rust stable** (**rustfmt**, **clippy**) per [`rust-toolchain.toml`](rust-toolchain.toml). Desktop build via Nix: [BUILD.md — Nix (flake)](BUILD.md#nix-flake). Details: [AGENTS.md](AGENTS.md).
+
+**Home Manager:** upstream patterns are summarized in **[Home Manager manual — Flakes](https://nix-community.github.io/home-manager/index.xhtml#ch-nix-flakes)** (e.g. **`inputs.home-manager.inputs.nixpkgs.follows`** in your flake, **`home-manager.extraSpecialArgs`**, **`useGlobalPkgs`**, **`useUserPackages`** where applicable). This repo exposes **`outputs.homeManagerModules.obsidianirc`** and **`outputs.homeModules.obsidianirc`** (same module). Detailed **`useGlobalPkgs`** overlay wiring: [BUILD.md — Nix (flake)](BUILD.md#nix-flake). If Home Manager doesn’t manage your shell, **`hm-session-vars.sh`** sourcing is unchanged from upstream — see the manual’s Installing / FAQ sections.
+
+**Optional — [direnv](https://direnv.net/) + Nix:** install the [shell hook](https://direnv.net/docs/hook.html), then **`direnv allow`** so [.envrc](.envrc) runs **`use flake`** (nix-direnv is optional; **`.direnv/`** is gitignored).
+
 Alternatively to run the full ObsidianIRC stack:
+
 ```sh
 docker compose up
 ```
 
 ## Coding Style
+
 We use [biome](https://biomejs.dev/guides/editors/first-party-extensions/) for linting and formatting.
 You can run the following command to check if your code is formatted correctly:
+
 ```sh
 npm run lint
 npm run format
 ```
 
 ## Git Hooks
+
 We use [lefthook](https://github.com/evilmartians/lefthook) for managing git hooks.
-We have commit hooks to enforce coding style. You can install the hoooks with:
+We have commit hooks to enforce coding style. You can install the hooks with:
+
 ```sh
 npm run commit-hook-install
 ```
@@ -35,6 +49,7 @@ Now every time you commit the lint and format commands will run automatically.
 ### Development Setup
 
 1. **Clone and install dependencies:**
+
    ```bash
    git clone https://github.com/ObsidianIRC/ObsidianIRC
    cd ObsidianIRC
@@ -42,6 +57,7 @@ Now every time you commit the lint and format commands will run automatically.
    ```
 
 2. **Start development server:**
+
    ```bash
    npm run dev
    ```
@@ -53,12 +69,15 @@ For testing features locally, we provide a complete IRC testing stack with Docke
 #### First-time setup (once per machine)
 
 Install [mkcert](https://github.com/FiloSottile/mkcert), then:
+
 ```bash
 npm run gen-certs
 ```
+
 This installs the local CA into your OS trust store and writes a `.env` file used by compose.
 
 #### Start the stack
+
 ```bash
 # in one terminal
 npm run dev

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,34 +1,45 @@
 # Installing Native Obsidian IRC
-Grab the latest version for your platform from https://github.com/ObsidianIRC/ObsidianIRC/releases
+
+Grab the latest version for your platform from [https://github.com/ObsidianIRC/ObsidianIRC/releases](https://github.com/ObsidianIRC/ObsidianIRC/releases)
 
 ## Choosing the Right Version
 
 ### Linux
+
 - **Intel/AMD 64-bit (x86_64/amd64)**: Most desktop/laptop PCs
   - `.deb` package: `ObsidianIRC_*_amd64.deb` for Debian/Ubuntu/ZorinOS
   - `.rpm` package: `ObsidianIRC-*-1.x86_64.rpm` for Fedora/CentOS/RHEL
   - AppImage: `ObsidianIRC_*_amd64.AppImage` for any Linux distro
-  
 - **ARM 64-bit (aarch64/arm64)**: Raspberry Pi 4/5, ARM servers
   - `.deb` package: `ObsidianIRC_*_arm64.deb` for Debian/Ubuntu
   - `.rpm` package: `ObsidianIRC-*-1.aarch64.rpm` for Fedora/CentOS/RHEL
   - AppImage: `ObsidianIRC_*_aarch64.AppImage` for any Linux distro
+- **NixOS / Nix-with-flakes (`x86_64-linux`, `aarch64-linux`)**:
+  - Direct build: `nix build .#obsidianirc`
+  - Home Manager module: `programs.obsidianirc` — see [nix/hm-module.nix](nix/hm-module.nix)
+  - Build instructions: [BUILD.md — Nix (flake)](BUILD.md#nix-flake)
+  - Note: This flake does not ship packages or devShells for macOS/Windows under Nix (use releases above or host toolchains — [BUILD.md](BUILD.md))
 
 ### macOS
+
 - **Intel Macs**: `ObsidianIRC_*_x64.dmg`
 - **Apple Silicon (M1/M2/M3)**: `ObsidianIRC_*_aarch64.dmg`
 
 ### Windows
+
 - `ObsidianIRC_*_x64-setup.exe` or `ObsidianIRC_*_x64_en-US.msi`
 
 ### Mobile
+
 - **Android**: `ObsidianIRC-*.apk` (unsigned - follow [this guide](https://developer.android.com/studio/run/install-apk))
 - **iOS**: `ObsidianIRC-*-unsigned.ipa` (use [LiveContainer](https://github.com/LiveContainer/LiveContainer) or [AltStore](https://altstore.io/))
 
 ### Web
+
 - `ObsidianIRC-*-web.zip` - Unzip and open `dist/index.html` in your browser
 
 ## Debian/Ubuntu/ZorinOS Prerequisites
+
 Before installing the `.deb` package, you need to install the required dependencies:
 
 ```sh
@@ -45,15 +56,14 @@ sudo apt install libwebkit2gtk-4.0-37 libgtk-3-0
 **Note:** If you get "package has unmet dependencies" errors even though the packages are installed, this is a known issue with some Tauri builds. Use one of these workarounds:
 
 1. **Force install** (not recommended but works):
-   ```sh
+  ```sh
    sudo dpkg -i --force-depends ObsidianIRC_*.deb
-   ```
-
+  ```
 2. **Use the AppImage instead** (recommended - no installation needed):
-   ```sh
+  ```sh
    chmod +x ObsidianIRC-*.AppImage
    ./ObsidianIRC-*.AppImage
-   ```
+  ```
 
 Standard installation after dependencies are installed:
 
@@ -107,21 +117,27 @@ Save as `~/bin/obsidianirc` and run `chmod +x ~/bin/obsidianirc`
 **Note for Developers:** To avoid this issue in releases, build on the oldest supported Ubuntu LTS (20.04 or 22.04) to ensure maximum compatibility.
 
 ## Google Playstore
+
 Coming soon.
 
 ## Apple App Store
+
 Not available yet.
 
 ## Arch Linux AUR
+
 Use the AUR helper of your choice to install ObsidianIRC. For example, using `yay`:
+
 ```sh
 yay -S obsidianirc
 ```
 
 ## Docker
+
 ```sh
-docker run -p 8080:80 mattfly/obdisianirc:latest
+docker run -p 8080:80 mattfly/obsidian:latest
 ```
 
-## Manual Build
-Refer to [BUILD.md](BUILD.md) for instructions on how to build ObsidianIRC from source.
+## Manual build and development
+
+Compiling from source: [BUILD.md](BUILD.md). Contributor setup (optional toolchains, hooks, local test stack): [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,11 +14,7 @@ Grab the latest version for your platform from [https://github.com/ObsidianIRC/O
   - `.deb` package: `ObsidianIRC_*_arm64.deb` for Debian/Ubuntu
   - `.rpm` package: `ObsidianIRC-*-1.aarch64.rpm` for Fedora/CentOS/RHEL
   - AppImage: `ObsidianIRC_*_aarch64.AppImage` for any Linux distro
-- **NixOS / Nix-with-flakes (`x86_64-linux`, `aarch64-linux`)**:
-  - Direct build: `nix build .#obsidianirc`
-  - Home Manager module: `programs.obsidianirc` — see [nix/hm-module.nix](nix/hm-module.nix)
-  - Build instructions: [BUILD.md — Nix (flake)](BUILD.md#nix-flake)
-  - Note: This flake does not ship packages or devShells for macOS/Windows under Nix (use releases above or host toolchains — [BUILD.md](BUILD.md))
+- **NixOS / Nix-with-flakes (`x86_64-linux`, `aarch64-linux`)**: Build from source — see [BUILD.md — Nix (flake)](BUILD.md#nix-flake).
 
 ### macOS
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778876681,
+        "narHash": "sha256-9XOIxYLBp+sJsPWNnNyk1aVfYXuuRJZ4Anpplm9Tn8g=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "c7fad8197070948d8aa02cb8922240ee129cab2e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778443072,
+        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "home-manager": "home-manager",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,144 @@
+{
+  description = "ObsidianIRC — dev shell and Linux desktop package (Tauri + Vite)";
+
+  # devShell + packages: x86_64-linux and aarch64-linux only (see BUILD.md / AGENTS.md).
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      # Pin HM’s nixpkgs to this flake’s input so checks and consumer overlays don’t pull two nixpkgs revisions.
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      home-manager,
+    }:
+    let
+      linux = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      # Linux-only outputs share the same shape; this avoids copy-pasting `system:` boilerplate per attribute.
+      forLinux =
+        attrs:
+        nixpkgs.lib.genAttrs linux (
+          system:
+          attrs (
+            import nixpkgs {
+              inherit system;
+              config.allowUnfree = false;
+            }
+          )
+        );
+      obsidianPackageArgs = import ./nix/package-args.nix { root = ./.; };
+      programsObsidianircHmModule = import ./nix/hm-module.nix;
+    in
+    {
+      # Thin wrapper: injects `pkgs.obsidianirc` on Linux when merged into nixpkgs (see nix/overlay.nix).
+      overlays.default = import ./nix/overlay.nix;
+
+      # HM manual + flake-parts use `flake.homeModules`; keep both spellings discoverable for consumers.
+      homeManagerModules.obsidianirc = programsObsidianircHmModule;
+      homeModules.obsidianirc = programsObsidianircHmModule;
+
+      devShells = forLinux (
+        pkgs:
+        let
+          inherit (pkgs) lib mkShell;
+          webkit = pkgs.webkitgtk_4_1;
+          tauriLibs = with pkgs; [
+            webkit
+            webkit.dev
+            gtk3
+            gtk3.dev
+            openssl
+            openssl.dev
+            glib-networking
+            librsvg
+            cairo
+            libayatana-appindicator
+            glib
+          ];
+        in
+        {
+          default = mkShell {
+            packages = with pkgs; [
+              nodejs_22
+              rustup
+              patchelf
+              gcc
+            ];
+            nativeBuildInputs = with pkgs; [ pkg-config ];
+            buildInputs = tauriLibs;
+            env = {
+              RUST_BACKTRACE = "1";
+            };
+            shellHook =
+              let
+                pkgcfg = lib.makeSearchPathOutput "dev" "lib/pkgconfig" tauriLibs;
+              in
+              ''
+                export PKG_CONFIG_PATH="${pkgcfg}''${PKG_CONFIG_PATH:+:}$PKG_CONFIG_PATH"
+                export LD_LIBRARY_PATH="${
+                  lib.makeLibraryPath [
+                    pkgs.glib
+                    pkgs.gtk3
+                    webkit
+                  ]
+                }''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH"
+                echo "(ObsidianIRC) node: $(node --version) • use \`rustup show\` after first compile"
+              '';
+          };
+        }
+      );
+
+      packages = forLinux (
+        pkgs:
+        let
+          pkg = pkgs.callPackage ./nix/obsidianirc.nix obsidianPackageArgs;
+        in
+        {
+          obsidianirc = pkg;
+          default = pkg;
+        }
+      );
+
+      # Smoke-evaluates the HM module via home-manager.lib using `hello` as a stub package so check never builds Tauri.
+      checks = nixpkgs.lib.genAttrs linux (
+        system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            config.allowUnfree = false;
+            overlays = [ self.overlays.default ];
+          };
+        in
+        {
+          home-manager-module =
+            (home-manager.lib.homeManagerConfiguration {
+              inherit pkgs;
+              modules = [
+                programsObsidianircHmModule
+                {
+                  home = {
+                    # Match HM manual examples (`home-manager` flake); only needs to evaluate for flake check.
+                    stateVersion = "25.11";
+                    username = "hm-oirc-check";
+                    homeDirectory = "/var/empty";
+                  };
+                  programs.obsidianirc = {
+                    enable = true;
+                    package = pkgs.hello;
+                  };
+                }
+              ];
+            }).activationPackage;
+        }
+      );
+    };
+}

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -1,0 +1,136 @@
+# Home Manager module: `programs.obsidianirc`.
+#
+# Consumer patterns (Home Manager manual — Nix Flakes):
+# - Pin inputs: prefer `inputs.home-manager.inputs.nixpkgs.follows = "nixpkgs"` in the *consumer* flake so HM and
+#   Nixpkgs stay on one revision.
+# - NixOS: import `home-manager.nixosModules.home-manager`; set `home-manager.useGlobalPkgs = true`, and normally
+#   `home-manager.useUserPackages = true` (recommended for `/etc/profiles`/build-vm ergonomics).
+# - Pass `home-manager.extraSpecialArgs = { inherit inputs; };` when modules need flake inputs (unlocks
+#   `inputs.obsidianirc.packages.${pkgs.system}.default` overrides).
+#
+# Overlay note: With `useGlobalPkgs`, `home-manager.users.<you>.nixpkgs.overlays` does not mutate the shared `pkgs`;
+# merge ./overlay.nix into the `nixpkgs` instantiation that feeds Home Manager (`nixpkgs.overlays`, flake `nixpkgs` import, …).
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.obsidianirc;
+
+  inherit (lib)
+    all
+    attrNames
+    generators
+    getExe
+    hasAttr
+    hasPrefix
+    literalExpression
+    mkEnableOption
+    mkIf
+    mkMerge
+    mkOption
+    types
+    ;
+
+  viteKeysOk = all (k: hasPrefix "VITE_" k) (attrNames cfg.viteBuildEnv);
+
+  # Empty viteBuildEnv keeps the configured drv as-is; non-empty requires `.override` so VITE_* actually rebakes the frontend.
+  finalPackage =
+    if cfg.viteBuildEnv == { } then
+      cfg.package
+    else
+      cfg.package.override { inherit (cfg) viteBuildEnv; };
+
+in
+{
+  options.programs.obsidianirc = {
+    enable = mkEnableOption "ObsidianIRC — Modern IRC Client for the web, desktop and mobile.";
+
+    package = mkOption {
+      type = types.package;
+      default =
+        if hasAttr "obsidianirc" pkgs then
+          pkgs.obsidianirc
+        else
+          throw ''
+            obsidianirc home-manager module: pkgs.obsidianirc missing.
+            Add this flake's overlay (outputs.overlays.default) to `nixpkgs.overlays`,
+            or set `programs.obsidianirc.package`, e.g. to
+            inputs.obsidianirc.packages.${pkgs.stdenv.hostPlatform.system}.default.
+          '';
+      defaultText = literalExpression "pkgs.obsidianirc";
+      description = ''
+        ObsidianIRC package.
+        Defaults to `pkgs.obsidianirc` after merging `outputs.overlays.default` into nixpkgs.
+        Use `.override { viteBuildEnv = { ... }; }` or the `viteBuildEnv` option below to set Vite env.
+      '';
+    };
+
+    viteBuildEnv = mkOption {
+      default = { };
+      type = types.attrsOf types.str;
+      example = literalExpression ''
+        {
+          # Example only — add any other keys allowed by `vite.config.ts` / BUILD.md (`VITE_*` strings).
+          VITE_DEFAULT_IRC_SERVER = "wss://irc.example.net";
+          VITE_DEFAULT_IRC_SERVER_NAME = "Example";
+          VITE_DEFAULT_IRC_CHANNELS = "#lobby";
+          VITE_HIDE_SERVER_LIST = "false";
+          VITE_TRUSTED_MEDIA_URLS = "https://matterbridge.example.com";
+        }
+      '';
+      description = ''
+        Bake-time overrides forwarded into `nix/obsidianirc.nix` (every key must start with `VITE_`).
+        The `example` is not a full list; omit a key to keep the source default. Full names: `vite.config.ts` (`define`),
+        GIF/Tenor API keys in client code (`import.meta.env`), and **BUILD.md**.
+      '';
+    };
+
+    autostart = mkEnableOption "Launch ObsidianIRC when your graphical session starts (XDG autostart). Requires Home Manager's XDG integration: xdg.enable should be true (usually the default).";
+  };
+
+  # mkMerge lets autostart stay a separate fragment; assertions still gate the whole enable=true subtree.
+  config = mkIf cfg.enable (mkMerge [
+    {
+      # Autostart writes under ~/.config (xdg); without HM XDG integration the file would land inconsistently / fail expectations.
+      assertions = [
+        {
+          assertion = !cfg.autostart || config.xdg.enable;
+          message = "programs.obsidianirc.autostart needs `xdg.enable = true` in Home Manager.";
+        }
+        {
+          assertion = viteKeysOk;
+          message = "programs.obsidianirc.viteBuildEnv: every key must start with VITE_.";
+        }
+        {
+          assertion = cfg.viteBuildEnv == { } || (cfg.package ? override);
+          message = "programs.obsidianirc.viteBuildEnv requires a package produced by ObsidianIRC’s flake/overlay (`callPackage` .override support). Replace `programs.obsidianirc.package` or simplify `viteBuildEnv`.";
+        }
+      ];
+
+      home.packages = [ finalPackage ];
+    }
+
+    (mkIf cfg.autostart {
+      xdg.configFile."autostart/obsidianirc.desktop".text = generators.toINI { } {
+        "Desktop Entry" = {
+          Type = "Application";
+          Name = "ObsidianIRC";
+          Comment = "Modern IRC Client for the web, desktop and mobile.";
+          Exec = getExe finalPackage;
+          Terminal = "false";
+          Categories = "Network;InstantMessaging;";
+          Keywords = "irc;chat;";
+        };
+      };
+    })
+
+    # Optional templates (not wired by default—the real desktop IDs live under
+    # `$cfg.package/share/applications/` from Tauri—adjust after `nix-build`/`nix path-info`).
+    #
+    # xdg.mimeApps.defaultApplications."x-scheme-handler/irc" = "…";
+    # xdg.mimeApps.defaultApplications."x-scheme-handler/ircs" = "…";
+  ]);
+}

--- a/nix/obsidianirc.nix
+++ b/nix/obsidianirc.nix
@@ -1,0 +1,111 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchNpmDeps,
+  npmHooks,
+  cargo-tauri,
+  wrapGAppsHook4,
+  pkg-config,
+  openssl,
+  webkitgtk_4_1,
+  glib-networking,
+  gtk3,
+  librsvg,
+  cairo,
+  libayatana-appindicator,
+  desktop-file-utils,
+  xdg-utils,
+  nodejs_22,
+  version,
+  src,
+  viteBuildEnv ? { },
+}:
+
+let
+  # `vite.config.ts` `define`: VITE_DEFAULT_IRC_* / VITE_HIDE_SERVER_LIST / VITE_TRUSTED_MEDIA_URLS / VITE_DEFAULT_OAUTH_* /
+  # VITE_BACKEND_URL (optional gif/Tenor: VITE_GIPHY_API_KEY, VITE_TENOR_API_KEY). Non-VITE_ keys error below.
+  # Drop empties early so unrelated keys don’t perturb the drv hash.
+  viteEnvFiltered = lib.pipe viteBuildEnv [
+    (lib.filterAttrs (_: v: v != null && toString v != ""))
+    (
+      filtered:
+      lib.mapAttrs (
+        name: value:
+        if lib.hasPrefix "VITE_" name then
+          value
+        else
+          throw ''
+            obsidianirc: viteBuildEnv key '${name}' must start with VITE_ (see vite.config.ts and BUILD.md).
+          ''
+      ) filtered
+    )
+  ];
+in
+
+rustPlatform.buildRustPackage (
+  {
+    pname = "obsidianirc";
+    inherit version src;
+
+    cargoLock = {
+      lockFile = ../src-tauri/Cargo.lock;
+    };
+
+    # Fetched npm tarball hash — bump when package-lock.json changes (Nix will print the expected value on mismatch).
+    npmDeps = fetchNpmDeps {
+      name = "obsidianirc-npm-deps-${version}";
+      inherit src;
+      hash = "sha256-PxkIPxw54tH/2GUN4lwPoDHGkzezQ2A+pMbJIAZ5TwA=";
+    };
+
+    nativeBuildInputs = [
+      # Runs the Vite/npm frontend build inside the Rust drv instead of a separate manual step.
+      cargo-tauri.hook
+      nodejs_22
+      npmHooks.npmConfigHook
+      pkg-config
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ wrapGAppsHook4 ];
+
+    buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+      gtk3
+      glib-networking
+      openssl
+      webkitgtk_4_1
+      librsvg
+      cairo
+      libayatana-appindicator
+    ];
+
+    cargoRoot = "src-tauri";
+    buildAndTestSubdir = "src-tauri";
+
+    # tauri-plugin-deep-link register_all() shells out to update-desktop-database and xdg-mime at runtime.
+    preFixup = ''
+      gappsWrapperArgs+=(--prefix PATH : "${
+        lib.makeBinPath [
+          desktop-file-utils
+          xdg-utils
+        ]
+      }")
+    '';
+
+    # Tauri tests require a display server and dbus session; skip in sandbox.
+    doCheck = false;
+
+    meta = {
+      description = "Modern IRC Client for the web, desktop and mobile.";
+      homepage = "https://github.com/ObsidianIRC/ObsidianIRC";
+      license = lib.licenses.gpl3Only;
+      mainProgram = "ObsidianIRC";
+      platforms = [
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+      maintainers = [ ];
+    };
+  }
+  # Extra top-level attrs become drv env for the hooks/phases that invoke npm/vite (see `viteBuildEnv` / HM module).
+  // viteEnvFiltered
+)

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,0 +1,14 @@
+# Example: merge into nixpkgs so consumers can use `pkgs.obsidianirc`.
+#
+# nixpkgs.overlays = [ inputs.obsidianirc.overlays.default ];
+# final/prev: overlay convention — package set after vs before this overlay (for layering fixes without pinning forks).
+_final: prev:
+let
+  inherit (prev) lib;
+  args = import ./package-args.nix { root = ../.; };
+in
+# Only define the attr on Linux hosts so evaluating pkgs on Darwin doesn’t pull an unsupported desktop closure.
+lib.optionalAttrs prev.stdenv.hostPlatform.isLinux {
+  # callPackage fills deps from nixpkgs and merges `args` (version/src/viteBuildEnv defaults) into obsidianirc.nix.
+  obsidianirc = prev.callPackage ./obsidianirc.nix args;
+}

--- a/nix/package-args.nix
+++ b/nix/package-args.nix
@@ -1,0 +1,34 @@
+# One place for version/src/viteBuildEnv defaults so flake `packages` and `overlays.default` stay in lockstep (no drift).
+{
+  root,
+  viteBuildEnv ? { },
+}:
+let
+  pkg = builtins.fromJSON (builtins.readFile (root + "/package.json"));
+  inherit (pkg) version;
+  src = builtins.path {
+    name = "obsidianirc-src";
+    path = root;
+    # Exclude files irrelevant to the build so doc/test edits don't invalidate the derivation hash.
+    filter =
+      path: _type:
+      let
+        baseName = baseNameOf path;
+      in
+      # Exclude .env / .env.* files (secrets/local config that must never enter the store).
+      !(builtins.match "\\.env(\\..*)?" baseName != null)
+      && !builtins.elem baseName [
+        ".git"
+        ".direnv"
+        ".envrc"
+        ".github"
+        "node_modules"
+        "result"
+        "tests"
+        "screenshots"
+      ];
+  };
+in
+{
+  inherit version src viteBuildEnv;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,9 @@
         "typescript-eslint": "^8.59.3",
         "vite": "^6.4.2",
         "vitest": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -9076,7 +9079,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.3.0",
   "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
   "homepage": "https://github.com/ObsidianIRC/ObsidianIRC",
   "scripts": {
     "dev": "vite --host 0.0.0.0",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+# rustup reads this for channel + rustfmt/clippy; MSRV is src-tauri/Cargo.toml rust-version.
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy"]

--- a/src/components/ui/AddServerModal.tsx
+++ b/src/components/ui/AddServerModal.tsx
@@ -114,10 +114,9 @@ export const AddServerModal: React.FC = () => {
       let finalHost = serverHost;
       if (isTauri()) {
         const port = Number.parseInt(serverPort, 10);
-        const cleanHost = serverHost.replace(
-          /^(https?|wss|ircs?|irc):\/\//,
-          "",
-        );
+        const cleanHost = serverHost
+          .replace(/^(https?|wss?|ircs?):\/\//, "")
+          .replace(/:\d+$/, "");
         finalHost = useWebSocket
           ? `wss://${cleanHost}:${port}`
           : `ircs://${cleanHost}:${port}`;


### PR DESCRIPTION
## Summary

Adds a Nix flake for reproducible development and native Linux packaging (x86_64, aarch64). Also fixes a Tauri connection bug discovered during testing.

## What's included

### Nix flake
- **`nix develop`** — Node 22, Tauri Linux libs (WebKitGTK 4.1, GTK 3, OpenSSL, etc.), rustup
- **`nix build .#obsidianirc`** — Full Tauri desktop build via `cargo-tauri.hook` + `fetchNpmDeps`
- **`overlays.default`** — Injects `pkgs.obsidianirc` into nixpkgs on Linux
- **Home Manager module** (`programs.obsidianirc`) — `viteBuildEnv` for baking VITE_* vars, XDG autostart option, assertions for proper overlay/xdg setup
- **`nix flake check`** — Smoke-evaluates the HM module without building Tauri
- **direnv** — `.envrc` with `use flake`
- **`rust-toolchain.toml`** — Pins stable + rustfmt/clippy

### CI
- New `nix-linux` job: `nix flake check && nix build` on ubuntu-latest

### Other
- `package.json`: `engines.node >= 22`
- Docs: Nix sections in AGENTS.md, BUILD.md, CONTRIBUTING.md, INSTALL.md, ARCHITECTURE.md

### Bug fix
- **AddServerModal**: Strip port from host string before rebuilding the connection URL. Fixes port duplication (e.g. `wss://host:6697:443`) when the discover grid prefills a host that already contains a port.

## Path to official nixpkgs

1. **This PR** — flake in-tree, users can `nix run github:ObsidianIRC/ObsidianIRC` or add to their flake inputs
2. **Cachix** (next) — push pre-built binaries so users don't compile Tauri from source
3. **nixpkgs upstream** — submit package based on `nix/obsidianirc.nix`. Once merged, Hydra builds it and every NixOS user gets it from `cache.nixos.org` for free

## Testing

- `npm run test` — 59 files, 785 passed ✅
- `npm run build` ✅
- `nix flake check` ✅
- `nix build .#obsidianirc` — binary launches and connects ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Nix flake support for Linux-based development and deployment environments.

* **Bug Fixes**
  * Fixed server host URL normalization to properly handle URL scheme prefixes and port suffixes.

* **Documentation**
  * Updated build, installation, and contribution guides with improved platform support and clearer setup instructions.
  * Added Nix-based deployment documentation.

* **Chores**
  * Updated tooling requirements: Node.js 22+ and stable Rust channel.
  * Enhanced CI pipeline with Nix build validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ObsidianIRC/ObsidianIRC/pull/224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->