### PR TITLE
feat: auto-join channel from ?channel= URL query

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,47 @@ const askPermissions = async () => {
   }
 };
 
+/* Channel auto-join from URL query string.
+ *
+ * When the hosted client is reached via an invite-page "Join via
+ * Web" link the URL carries `?channel=<urlencoded>` (the obbyircd
+ * invite-page module appends it on channel-specific invites). Read
+ * the param once on module load, normalise the value, and stash for
+ * the first `ready` event to consume.  The query param is stripped
+ * from the visible address bar immediately so a refresh doesn't
+ * silently re-fire the auto-join. */
+let pendingJoinChannel: string | null = null;
+if (typeof window !== "undefined") {
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const raw = params.get("channel");
+    if (raw) {
+      const trimmed = raw.trim();
+      if (trimmed) {
+        // Accept both encoded ("%23weather") and unencoded ("#weather")
+        // forms.  Default to a `#` prefix when the caller passed a
+        // bare channel name; sigils &, ^, $ are preserved verbatim.
+        const first = trimmed.charAt(0);
+        pendingJoinChannel =
+          first === "#" || first === "&" || first === "^" || first === "$"
+            ? trimmed
+            : `#${trimmed}`;
+      }
+      // Strip the param so refreshes don't re-trigger.  Preserve any
+      // other query params the host page may use.
+      params.delete("channel");
+      const remaining = params.toString();
+      const newUrl =
+        window.location.pathname +
+        (remaining ? `?${remaining}` : "") +
+        window.location.hash;
+      window.history.replaceState({}, "", newUrl);
+    }
+  } catch {
+    /* malformed URL -- silently ignore */
+  }
+}
+
 const initializeEnvSettings = (
   toggleAddServerModal: (
     isOpen?: boolean,
@@ -100,6 +141,7 @@ const App: React.FC = () => {
       prefillServerDetails,
     },
     joinChannel,
+    selectChannel,
     connectToSavedServers,
     toggleServerNoticesPopup,
     clearProfileViewRequest,
@@ -172,7 +214,33 @@ const App: React.FC = () => {
     hasInitialized.current = true;
     initializeEnvSettings(toggleAddServerModal, joinChannel);
     connectToSavedServers();
-  }, [connectToSavedServers, joinChannel, toggleAddServerModal]);
+
+    /* Auto-join the channel encoded in `?channel=` on the URL the
+     * user landed on.  Fires on the first server that finishes
+     * registration so persistence reconnects and fresh connects both
+     * get caught.  Channel pending state is module-scoped and
+     * consumed exactly once. */
+    if (pendingJoinChannel) {
+      const onReady = ({ serverId }: { serverId: string }) => {
+        if (!pendingJoinChannel) return;
+        const channel = pendingJoinChannel;
+        pendingJoinChannel = null;
+        joinChannel(serverId, channel);
+        // Wait a tick for the JOIN echo to register the channel in
+        // the store, then focus it.  Same pattern UserProfileModal
+        // uses for click-to-join.
+        setTimeout(() => {
+          const srv = useStore
+            .getState()
+            .servers.find((s) => s.id === serverId);
+          const ch = srv?.channels.find((c) => c.name === channel);
+          if (ch) selectChannel(ch.id, { navigate: true });
+        }, 200);
+        ircClient.deleteHook("ready", onReady);
+      };
+      ircClient.on("ready", onReady);
+    }
+  }, [connectToSavedServers, joinChannel, selectChannel, toggleAddServerModal]);
 
   // When the server list is hidden and all saved-server connections fail, the user
   // has no other way to open the login modal, so we open it automatically.


### PR DESCRIPTION
## Summary
Closes https://github.com/ObsidianIRC/ObsidianIRC/issues/113

When the obbyircd invite-page module's \"Join via Web\" button is clicked on a channel-specific invite, the hosted client URL now carries \`?channel=%23weather\` (or similar). This PR makes the client read that param on page load and auto-join + select that channel after the first server reaches \`ready\`.

Pairs with [obbyircd commit 61b5f2503](https://github.com/ObsidianIRC/ObbyIRCd/commit/61b5f2503) which started emitting the param server-side.

## Wire

1. `src/App.tsx` parses `URLSearchParams.get("channel")` once at module load, stashes the normalised channel name in module-scope state, and strips the param via `history.replaceState` so refreshes don't re-fire.
2. The main init `useEffect` registers a `ready` handler that fires once, joins + selects the pending channel on the first server that finishes registration, and deregisters itself.

## Accepted forms

- `?channel=%23weather` (URL-encoded sigil) → joins `#weather`

- `?channel=#weather` (raw sigil) → joins `#weather`

- `?channel=weather` (bare) → joins `#weather` (default sigil prepended)

- `?channel=&private` → `&private` (other channel-type sigils preserved)

## Test plan

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for auto-joining IRC channels via URL query parameter (e.g., `?channel=...`). The app automatically normalizes channel names, removes the parameter from the browser URL, and focuses the UI on the newly joined channel.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ObsidianIRC/ObsidianIRC/pull/230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->