### PR TITLE
ci(nix): automate npmDeps hash and verify Nix builds on release tags

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -83,8 +83,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ steps.package-version.outputs.tag_name }}
 
-  publish-nix:
-    name: Nix package (Linux x86_64)
+  verify-nix:
+    name: Verify Nix package (Linux x86_64)
     if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -83,7 +83,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ steps.package-version.outputs.tag_name }}
 
-  verify-linux-nix:
+  update-linux-nix:
     if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -111,6 +111,9 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Verify step may patch this file; discard before switching to main.
+          git restore nix/obsidianirc.nix
+
           git fetch origin main
           git checkout main
           git pull --rebase origin main

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -101,17 +101,9 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
 
-      - name: Verify tagged release builds
-        run: |
-          nix run .#update-npm-deps-hash
-          nix flake check && nix build .#obsidianirc --no-link --print-build-logs
-
-      - name: Commit npmDeps hash to main
+      - name: Update npmDeps hash on main
         run: |
           set -euo pipefail
-
-          # Verify step may patch this file; discard before switching to main.
-          git restore nix/obsidianirc.nix
 
           git fetch origin main
           git checkout main
@@ -124,7 +116,7 @@ jobs:
             exit 0
           fi
 
-          nix build .#obsidianirc --no-link --print-build-logs
+          nix flake check && nix build .#obsidianirc --no-link --print-build-logs
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -83,6 +83,53 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ steps.package-version.outputs.tag_name }}
 
+  publish-nix:
+    name: Nix package (Linux x86_64)
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Verify tagged release builds
+        run: |
+          nix run .#update-npm-deps-hash
+          nix flake check && nix build .#obsidianirc --no-link --print-build-logs
+
+      - name: Commit npmDeps hash to main
+        run: |
+          set -euo pipefail
+
+          git fetch origin main
+          git checkout main
+          git pull --rebase origin main
+
+          nix run .#update-npm-deps-hash
+
+          if git diff --exit-code --quiet -- nix/obsidianirc.nix; then
+            echo "npmDeps hash on main is already up to date."
+            exit 0
+          fi
+
+          nix build .#obsidianirc --no-link --print-build-logs
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add nix/obsidianirc.nix
+          git commit -m "build(nix): update npmDeps hash [skip ci]"
+          git push origin main
+
   publish-tauri:
     needs: collect-version
     permissions:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -83,8 +83,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ steps.package-version.outputs.tag_name }}
 
-  verify-nix:
-    name: Verify Nix package (Linux x86_64)
+  verify-linux-nix:
     if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -29,19 +29,6 @@ jobs:
     - name: Test
       run: npm run test
 
-  nix-linux:
-    name: Nix package (Linux x86_64)
-    timeout-minutes: 60
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-      - name: Build obsidianirc
-        run: nix flake check && nix build .#obsidianirc --no-link --print-build-logs
-
   i18n:
     name: i18n Catalog Check
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ npm run format; npm run fix:unsafe; npm run test; npm run build
 ## Nix
 
 - **`nix develop`** — full dev environment (Node 22 + Tauri Linux deps + rustup). Linux only (`x86_64`/`aarch64`).
-- **`nix build .#obsidianirc`** — produces `result/bin/ObsidianIRC`. Bump `npmDeps` in [nix/obsidianirc.nix](nix/obsidianirc.nix) when `package-lock.json` changes.
+- **`nix build .#obsidianirc`** — produces `result/bin/ObsidianIRC`. When `package-lock.json` changes, run `nix run .#update-npm-deps-hash` before pushing (lefthook does this locally if Nix is installed); release tags also sync the hash to `main` via [`publish.yaml`](.github/workflows/publish.yaml).
 - Details: [BUILD.md — Nix (flake)](BUILD.md#nix-flake)
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ npm run format; npm run fix:unsafe; npm run test; npm run build
 ## Nix
 
 - **`nix develop`** — full dev environment (Node 22 + Tauri Linux deps + rustup). Linux only (`x86_64`/`aarch64`).
-- **`nix build .#obsidianirc`** — produces `result/bin/ObsidianIRC`. When `package-lock.json` changes, run `nix run .#update-npm-deps-hash` before pushing (lefthook does this locally if Nix is installed); release tags also sync the hash to `main` via [`publish.yaml`](.github/workflows/publish.yaml).
+- **`nix build .#obsidianirc`** — produces `result/bin/ObsidianIRC`. When `package-lock.json` changes, run `nix run .#update-npm-deps-hash` if you have Nix locally; otherwise `verify-linux-nix` in [`publish.yaml`](.github/workflows/publish.yaml) syncs the hash to `main` on version tags.
 - Details: [BUILD.md — Nix (flake)](BUILD.md#nix-flake)
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ npm run format; npm run fix:unsafe; npm run test; npm run build
 ## Nix
 
 - **`nix develop`** — full dev environment (Node 22 + Tauri Linux deps + rustup). Linux only (`x86_64`/`aarch64`).
-- **`nix build .#obsidianirc`** — produces `result/bin/ObsidianIRC`. When `package-lock.json` changes, run `nix run .#update-npm-deps-hash` if you have Nix locally; otherwise `verify-linux-nix` in [`publish.yaml`](.github/workflows/publish.yaml) syncs the hash to `main` on version tags.
+- **`nix build .#obsidianirc`** — produces `result/bin/ObsidianIRC`. When `package-lock.json` changes, run `nix run .#update-npm-deps-hash` if you have Nix locally; otherwise `update-linux-nix` in [`publish.yaml`](.github/workflows/publish.yaml) syncs the hash to `main` on version tags.
 - Details: [BUILD.md — Nix (flake)](BUILD.md#nix-flake)
 ---
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -168,7 +168,7 @@ nix build .#obsidianirc  # → result/bin/ObsidianIRC
 
 - **direnv:** `direnv allow` activates [.envrc](.envrc) (`use flake`).
 - **Home Manager:** `programs.obsidianirc` module — see [nix/hm-module.nix](nix/hm-module.nix) for options and usage.
-- **Maintenance:** bump `npmDeps` in [nix/obsidianirc.nix](nix/obsidianirc.nix) when `package-lock.json` changes.
+- **Maintenance:** when `package-lock.json` changes, run `nix run .#update-npm-deps-hash` before pushing (lefthook does this locally if Nix is installed). On version tag releases, [`publish.yaml`](.github/workflows/publish.yaml) verifies the Nix package and commits any hash fix to `main`.
 ### macOS
 
 ```sh

--- a/BUILD.md
+++ b/BUILD.md
@@ -168,7 +168,7 @@ nix build .#obsidianirc  # → result/bin/ObsidianIRC
 
 - **direnv:** `direnv allow` activates [.envrc](.envrc) (`use flake`).
 - **Home Manager:** `programs.obsidianirc` module — see [nix/hm-module.nix](nix/hm-module.nix) for options and usage.
-- **Maintenance:** when `package-lock.json` changes, run `nix run .#update-npm-deps-hash` before pushing (lefthook does this locally if Nix is installed). On version tag releases, [`publish.yaml`](.github/workflows/publish.yaml) verifies the Nix package and commits any hash fix to `main`.
+- **Maintenance:** when `package-lock.json` changes, run `nix run .#update-npm-deps-hash` if you have Nix locally. On version tag releases, [`publish.yaml`](.github/workflows/publish.yaml) (`verify-linux-nix`) verifies the Nix package and commits any hash fix to `main`.
 ### macOS
 
 ```sh

--- a/BUILD.md
+++ b/BUILD.md
@@ -168,7 +168,7 @@ nix build .#obsidianirc  # → result/bin/ObsidianIRC
 
 - **direnv:** `direnv allow` activates [.envrc](.envrc) (`use flake`).
 - **Home Manager:** `programs.obsidianirc` module — see [nix/hm-module.nix](nix/hm-module.nix) for options and usage.
-- **Maintenance:** when `package-lock.json` changes, run `nix run .#update-npm-deps-hash` if you have Nix locally. On version tag releases, [`publish.yaml`](.github/workflows/publish.yaml) (`verify-linux-nix`) verifies the Nix package and commits any hash fix to `main`.
+- **Maintenance:** when `package-lock.json` changes, run `nix run .#update-npm-deps-hash` if you have Nix locally. On version tag releases, [`publish.yaml`](.github/workflows/publish.yaml) (`update-linux-nix`) builds the Nix package and commits any hash fix to `main`.
 ### macOS
 
 ```sh

--- a/flake.nix
+++ b/flake.nix
@@ -101,10 +101,12 @@
         pkgs:
         let
           pkg = pkgs.callPackage ./nix/obsidianirc.nix obsidianPackageArgs;
+          update-npm-deps-hash = pkgs.callPackage ./nix/update-npm-deps-hash.nix { };
         in
         {
           obsidianirc = pkg;
           default = pkg;
+          inherit update-npm-deps-hash;
         }
       );
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -30,17 +30,3 @@ pre-commit:
           echo "Catalog changes have been staged. Re-run git commit to proceed."
           exit 1
         fi
-    npm-deps-hash:
-      glob: "package-lock.json"
-      skip:
-        - run: "! command -v nix"
-      run: |
-        set -e
-        nix run .#update-npm-deps-hash
-        if ! git diff --exit-code --quiet nix/obsidianirc.nix 2>/dev/null; then
-          git add nix/obsidianirc.nix
-          echo ""
-          echo "npmDeps hash updated in nix/obsidianirc.nix. Changes have been staged."
-          echo "Re-run git commit to proceed."
-          exit 1
-        fi

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -30,3 +30,17 @@ pre-commit:
           echo "Catalog changes have been staged. Re-run git commit to proceed."
           exit 1
         fi
+    npm-deps-hash:
+      glob: "package-lock.json"
+      skip:
+        - run: "! command -v nix"
+      run: |
+        set -e
+        nix run .#update-npm-deps-hash
+        if ! git diff --exit-code --quiet nix/obsidianirc.nix 2>/dev/null; then
+          git add nix/obsidianirc.nix
+          echo ""
+          echo "npmDeps hash updated in nix/obsidianirc.nix. Changes have been staged."
+          echo "Re-run git commit to proceed."
+          exit 1
+        fi

--- a/nix/update-npm-deps-hash.nix
+++ b/nix/update-npm-deps-hash.nix
@@ -1,0 +1,17 @@
+# Recomputes fetchNpmDeps hash from package-lock.json and patches nix/obsidianirc.nix.
+# Run: nix run .#update-npm-deps-hash
+{ pkgs }:
+
+pkgs.writeShellApplication {
+  name = "update-npm-deps-hash";
+  runtimeInputs = with pkgs; [
+    prefetch-npm-deps
+    gnused
+  ];
+  text = ''
+    set -euo pipefail
+    hash=$(prefetch-npm-deps package-lock.json)
+    echo "updated npmDeps hash: $hash" >&2
+    sed -i "s|hash = \"sha256-[^\"]*\";|hash = \"$hash\";|" nix/obsidianirc.nix
+  '';
+}


### PR DESCRIPTION
## Summary

- Add `nix run .#update-npm-deps-hash` to recompute `fetchNpmDeps` from `package-lock.json` and patch `nix/obsidianirc.nix`
- Add a lefthook pre-commit hook (runs when Nix is installed) so lockfile changes fix the hash before push
- Remove the `nix-linux` job from daily CI — Dependabot PRs no longer need to pass a 60-minute Nix build
- Add `publish-nix` to the release workflow: on version tags, verify the Nix package builds and commit any hash fix back to `main`

## Motivation

When `package-lock.json` changes (weekly Dependabot updates, new features, etc.), the `npmDeps` hash in `nix/obsidianirc.nix` must stay in sync or Nix builds fail. That was easy to miss and blocked CI.

This follows the approach discussed with @mattf:
- **Fix before push** locally via lefthook (optional if Nix is installed)
- **Don't gate every push/PR** on Nix — too slow for a young node project with frequent dep changes
- **Sync at release time** — tag pushes verify the Nix package and push hash fixes to `main` with `[skip ci]`

## Changes

| Area | What |
|------|------|
| `nix/update-npm-deps-hash.nix` | Flake app using `prefetch-npm-deps` + `sed` |
| `flake.nix` | Expose `packages.update-npm-deps-hash` |
| `lefthook.yml` | `npm-deps-hash` command on staged `package-lock.json` changes |
| `.github/workflows/workflow.yaml` | Remove `nix-linux` job |
| `.github/workflows/publish.yaml` | New `publish-nix` job (`if: github.ref_type == 'tag'`) |
| `AGENTS.md`, `BUILD.md` | Updated maintenance docs |

## Test plan

- [x] `nix flake check`
- [x] `nix build .#obsidianirc` (~3.4 min, passes)
- [x] `nix run .#update-npm-deps-hash` (idempotent on current lockfile)
- [x] Lefthook `npm-deps-hash` with stale hash → fixes, stages, aborts commit
- [x] `statix` / `deadnix` / `nixfmt` on Nix files
- [x] `actionlint` on workflows (syntax clean)
- [x] `npm run format` / `fix:unsafe` / `test` / `build`
- [ ] After merge: confirm next version tag runs `publish-nix` and syncs hash to `main` if needed

## Notes

- Devs **without Nix** can still commit lockfile changes; hash sync happens at the next tag release (or they ask someone with Nix to run `nix run .#update-npm-deps-hash`)
- `publish-nix` runs in parallel with Tauri release builds, not in the lint/test workflow


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized CI/CD pipeline—moved Nix package verification to tag-triggered release builds.
  * Automated NPM dependency hash synchronization during version releases.

* **Documentation**
  * Updated build maintenance instructions to reflect changes in dependency handling workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ObsidianIRC/ObsidianIRC/pull/235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->