### PR TITLE
feat(uploads): tokenless draft/FILEHOST + origin-based media trust

### DIFF
--- a/src/components/layout/ChannelList.tsx
+++ b/src/components/layout/ChannelList.tsx
@@ -28,6 +28,7 @@ import {
   getChannelDisplayName,
   isUrlFromFilehost,
   processMarkdownInText,
+  serverFilehosts,
 } from "../../lib/ircUtils";
 import { mediaLevelToSettings } from "../../lib/mediaUtils";
 import { isTauriDesktop, isTauriMobile } from "../../lib/platformUtils";
@@ -660,10 +661,9 @@ export const ChannelList: React.FC<{
                                 );
                                 const isFilehostAvatar =
                                   avatarUrl &&
-                                  selectedServer?.filehost &&
                                   isUrlFromFilehost(
                                     avatarUrl,
-                                    selectedServer.filehost,
+                                    serverFilehosts(selectedServer),
                                   );
                                 const shouldShowAvatar =
                                   avatarUrl &&
@@ -716,9 +716,9 @@ export const ChannelList: React.FC<{
                                     );
                                     const isFilehostAvatar =
                                       avatarUrl &&
-                                      selectedServer?.filehost &&
-                                      avatarUrl.startsWith(
-                                        selectedServer.filehost,
+                                      isUrlFromFilehost(
+                                        avatarUrl,
+                                        serverFilehosts(selectedServer),
                                       );
                                     const shouldShowAvatar =
                                       avatarUrl &&
@@ -1159,10 +1159,9 @@ export const ChannelList: React.FC<{
                               );
                               const isFilehostAvatar =
                                 avatarUrl &&
-                                selectedServer?.filehost &&
                                 isUrlFromFilehost(
                                   avatarUrl,
-                                  selectedServer.filehost,
+                                  serverFilehosts(selectedServer),
                                 );
                               const shouldShowAvatar =
                                 avatarUrl &&
@@ -1214,10 +1213,9 @@ export const ChannelList: React.FC<{
                               );
                               const isFilehostAvatar =
                                 avatarUrl &&
-                                selectedServer?.filehost &&
                                 isUrlFromFilehost(
                                   avatarUrl,
-                                  selectedServer.filehost,
+                                  serverFilehosts(selectedServer),
                                 );
                               const shouldShowAvatar =
                                 avatarUrl &&
@@ -1698,8 +1696,10 @@ export const ChannelList: React.FC<{
                   );
                   const isFilehostAvatar =
                     avatarUrl &&
-                    selectedServer?.filehost &&
-                    isUrlFromFilehost(avatarUrl, selectedServer.filehost);
+                    isUrlFromFilehost(
+                      avatarUrl,
+                      serverFilehosts(selectedServer),
+                    );
                   const shouldShowAvatar =
                     avatarUrl &&
                     ((isFilehostAvatar && showSafeMedia) ||

--- a/src/components/layout/ChatArea.tsx
+++ b/src/components/layout/ChatArea.tsx
@@ -27,6 +27,7 @@ import { parseIrcUrl } from "../../lib/ircUrlParser";
 import {
   fetchUploadInfo,
   uploadFile,
+  uploadFileTokenless,
   validateFileAgainstInfo,
 } from "../../lib/mediaUpload";
 import {
@@ -607,6 +608,12 @@ export const ChatArea: React.FC<{
     [servers, selectedServerId],
   );
 
+  // The server offers file uploads via either the vendor token uploader
+  // (obby.world/FILEHOST) or the standard tokenless one (draft/FILEHOST).
+  const canUpload = !!(
+    selectedServer?.filehost || selectedServer?.fileHosts?.length
+  );
+
   const selectedChannel = useMemo(
     () => selectedServer?.channels.find((c) => c.id === selectedChannelId),
     [selectedServer, selectedChannelId],
@@ -916,36 +923,37 @@ export const ChatArea: React.FC<{
   // progress, and on full success sends a single PRIVMSG containing
   // all the resulting URLs separated by spaces.
   const handleFilesUpload = async (files: File[]) => {
-    if (!selectedServer?.filehost || !selectedServerId || files.length === 0) {
-      return;
-    }
-    const filehostUrl = selectedServer.filehost;
+    if (!selectedServerId || files.length === 0) return;
+    // Prefer the standard tokenless draft/FILEHOST when offered; otherwise
+    // fall back to the vendor token-authenticated obby.world/FILEHOST.
+    const tokenlessEndpoint = selectedServer?.fileHosts?.[0];
+    const filehostUrl = selectedServer?.filehost;
+    if (!tokenlessEndpoint && !filehostUrl) return;
     const target = selectedChannel?.name ?? selectedPrivateChat?.username;
     if (!target) return;
 
-    // Pre-flight: pull the policy so we can reject obviously-bad
-    // files before pushing bytes.
-    const info = await fetchUploadInfo(filehostUrl);
-
-    // Acquire one draft/authtoken Bearer per file.  Tokens are
-    // single-use (the IRCd consumes each one on the validate-RPC the
-    // backend runs before accepting the upload), so we can't share
-    // a single Bearer across the batch like the old EXTJWT path did.
-    // Mints are serialised because `waitForAuthToken` resolves on the
-    // first matching TOKEN_GENERATE event -- parallel mints would
-    // race for the same reply.
-    const scope = target?.startsWith("#") ? `channel:${target}` : undefined;
+    // The token path pulls the in-house policy and mints one single-use
+    // draft/authtoken Bearer per file (the IRCd burns each on validate, so
+    // they can't be shared across the batch). The tokenless path needs
+    // neither -- it POSTs straight to the advertised endpoint.
+    let info: Awaited<ReturnType<typeof fetchUploadInfo>> = null;
     const tokens: string[] = [];
-    for (let i = 0; i < files.length; i++) {
-      ircClient.requestToken(selectedServerId, "filehost", scope);
-      const tok = await waitForAuthToken(selectedServerId, "filehost");
-      if (!tok) {
-        console.error(
-          "draft/authtoken: server did not return a filehost token",
-        );
-        return;
+    if (!tokenlessEndpoint && filehostUrl) {
+      info = await fetchUploadInfo(filehostUrl);
+      // Serialised because waitForAuthToken resolves on the first matching
+      // TOKEN_GENERATE event -- parallel mints would race for the reply.
+      const scope = target.startsWith("#") ? `channel:${target}` : undefined;
+      for (let i = 0; i < files.length; i++) {
+        ircClient.requestToken(selectedServerId, "filehost", scope);
+        const tok = await waitForAuthToken(selectedServerId, "filehost");
+        if (!tok) {
+          console.error(
+            "draft/authtoken: server did not return a filehost token",
+          );
+          return;
+        }
+        tokens.push(tok);
       }
-      tokens.push(tok);
     }
 
     // Build the job list in one go so the progress strip appears
@@ -981,12 +989,21 @@ export const ChatArea: React.FC<{
         uploadAbortsRef.current.set(job.id, ac);
         updateJob(job.id, { status: "uploading" });
         try {
-          const url = await uploadFile(job.file, {
-            filehostUrl,
-            bearerToken: tokens[jobIdx],
-            signal: ac.signal,
-            onProgress: (loaded, total) => updateJob(job.id, { loaded, total }),
-          });
+          const onProgress = (loaded: number, total: number) =>
+            updateJob(job.id, { loaded, total });
+          const url = tokenlessEndpoint
+            ? await uploadFileTokenless(job.file, {
+                endpoint: tokenlessEndpoint,
+                signal: ac.signal,
+                onProgress,
+              })
+            : await uploadFile(job.file, {
+                // biome-ignore lint/style/noNonNullAssertion: filehostUrl is set when tokenlessEndpoint isn't (guarded above)
+                filehostUrl: filehostUrl!,
+                bearerToken: tokens[jobIdx],
+                signal: ac.signal,
+                onProgress,
+              });
           updateJob(job.id, {
             status: "done",
             loaded: job.file.size,
@@ -1067,14 +1084,14 @@ export const ChatArea: React.FC<{
     Array.from(e.dataTransfer.types).includes("Files");
 
   const handleDragEnter = (e: React.DragEvent) => {
-    if (!selectedServer?.filehost || !dragHasFiles(e)) return;
+    if (!canUpload || !dragHasFiles(e)) return;
     e.preventDefault();
     dragDepthRef.current += 1;
     setIsDraggingFile(true);
   };
 
   const handleDragOver = (e: React.DragEvent) => {
-    if (!selectedServer?.filehost || !dragHasFiles(e)) return;
+    if (!canUpload || !dragHasFiles(e)) return;
     e.preventDefault();
     e.dataTransfer.dropEffect = "copy";
   };
@@ -1086,7 +1103,7 @@ export const ChatArea: React.FC<{
   };
 
   const handleDrop = (e: React.DragEvent) => {
-    if (!selectedServer?.filehost || !dragHasFiles(e)) return;
+    if (!canUpload || !dragHasFiles(e)) return;
     e.preventDefault();
     dragDepthRef.current = 0;
     setIsDraggingFile(false);
@@ -2170,7 +2187,7 @@ export const ChatArea: React.FC<{
                     left: "16px",
                   }}
                 >
-                  {selectedServer?.filehost && (
+                  {canUpload && (
                     <button
                       className="w-full text-left px-4 py-2 text-discord-text-normal hover:bg-discord-dark-300 rounded-lg flex items-center"
                       onClick={() => {

--- a/src/components/layout/ChatHeader.tsx
+++ b/src/components/layout/ChatHeader.tsx
@@ -26,6 +26,7 @@ import {
   getChannelAvatarUrl,
   getChannelDisplayName,
   isUrlFromFilehost,
+  serverFilehosts,
 } from "../../lib/ircUtils";
 import { mediaLevelToSettings } from "../../lib/mediaUtils";
 import { isTauriMobile } from "../../lib/platformUtils";
@@ -416,8 +417,7 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
               );
               const isFilehostAvatar =
                 avatarUrl &&
-                selectedServer?.filehost &&
-                isUrlFromFilehost(avatarUrl, selectedServer.filehost);
+                isUrlFromFilehost(avatarUrl, serverFilehosts(selectedServer));
               const shouldShowAvatar =
                 avatarUrl &&
                 ((isFilehostAvatar && showSafeMedia) || showExternalContent);
@@ -461,8 +461,10 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
                       );
                       const isFilehostAvatar =
                         avatarUrl &&
-                        selectedServer?.filehost &&
-                        isUrlFromFilehost(avatarUrl, selectedServer.filehost);
+                        isUrlFromFilehost(
+                          avatarUrl,
+                          serverFilehosts(selectedServer),
+                        );
                       const shouldShowAvatar =
                         avatarUrl &&
                         ((isFilehostAvatar && showSafeMedia) ||
@@ -676,8 +678,10 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
                 );
                 const isFilehostAvatar =
                   privateChatAvatar &&
-                  selectedServer?.filehost &&
-                  isUrlFromFilehost(privateChatAvatar, selectedServer.filehost);
+                  isUrlFromFilehost(
+                    privateChatAvatar,
+                    serverFilehosts(selectedServer),
+                  );
                 const shouldShowAvatar =
                   privateChatAvatar &&
                   ((isFilehostAvatar && showSafeMedia) ||

--- a/src/components/layout/MemberList.tsx
+++ b/src/components/layout/MemberList.tsx
@@ -8,6 +8,7 @@ import {
   getColorStyle,
   isUrlFromFilehost,
   processMarkdownInText,
+  serverFilehosts,
 } from "../../lib/ircUtils";
 import { mediaLevelToSettings } from "../../lib/mediaUtils";
 import useStore from "../../store";
@@ -151,9 +152,7 @@ const UserItem: React.FC<{
 
   // Determine if avatar should be shown based on media controls
   const isFilehostAvatar =
-    avatarUrl &&
-    server?.filehost &&
-    isUrlFromFilehost(avatarUrl, server.filehost);
+    avatarUrl && isUrlFromFilehost(avatarUrl, serverFilehosts(server));
   const shouldShowAvatar =
     avatarUrl &&
     ((isFilehostAvatar && showSafeMedia) || showExternalContent) &&

--- a/src/components/layout/ServerList.tsx
+++ b/src/components/layout/ServerList.tsx
@@ -5,7 +5,7 @@ import { FaPencilAlt, FaPlus, FaRedo, FaTrash } from "react-icons/fa";
 import { useLongPress } from "../../hooks/useLongPress";
 import { useMediaQuery } from "../../hooks/useMediaQuery";
 import ircClient from "../../lib/ircClient";
-import { isUrlFromFilehost } from "../../lib/ircUtils";
+import { isUrlFromFilehost, serverFilehosts } from "../../lib/ircUtils";
 import { mediaLevelToSettings } from "../../lib/mediaUtils";
 import useStore from "../../store";
 import type { Server } from "../../types";
@@ -45,7 +45,7 @@ const ServerIcon: React.FC<ServerIconProps> = ({
 
   const iconUrl = server.icon;
   const isFilehostIcon =
-    !!iconUrl && isUrlFromFilehost(iconUrl, server.filehost ?? "");
+    !!iconUrl && isUrlFromFilehost(iconUrl, serverFilehosts(server));
   const showIcon =
     !!iconUrl && ((isFilehostIcon && showSafeMedia) || showExternalContent);
 

--- a/src/components/message/LinkPreview.tsx
+++ b/src/components/message/LinkPreview.tsx
@@ -1,7 +1,7 @@
 import { useLingui } from "@lingui/react/macro";
 import type React from "react";
 import { useState } from "react";
-import { isUrlFromTrustedSource } from "../../lib/ircUtils";
+import { isUrlFromTrustedSource, serverFilehosts } from "../../lib/ircUtils";
 import { mediaLevelToSettings } from "../../lib/mediaUtils";
 import { stripIrcFormatting } from "../../lib/messageFormatter";
 import { openExternalUrl } from "../../lib/openUrl";
@@ -49,7 +49,7 @@ export const LinkPreview: React.FC<LinkPreviewProps> = ({
 
   // Check if image is from a trusted source (server filehost or globally configured trusted URLs)
   const isTrustedImage =
-    imageUrl && isUrlFromTrustedSource(imageUrl, server?.filehost);
+    imageUrl && isUrlFromTrustedSource(imageUrl, serverFilehosts(server));
   // Show image if it's from a trusted source and safe media is enabled, or if external content is allowed
   const shouldShowImage =
     imageUrl && ((isTrustedImage && showSafeMedia) || showExternalContent);

--- a/src/components/message/MessageAvatar.tsx
+++ b/src/components/message/MessageAvatar.tsx
@@ -1,6 +1,6 @@
 import type React from "react";
 import { useState } from "react";
-import { isUrlFromTrustedSource } from "../../lib/ircUtils";
+import { isUrlFromTrustedSource, serverFilehosts } from "../../lib/ircUtils";
 import { mediaLevelToSettings } from "../../lib/mediaUtils";
 import useStore from "../../store";
 
@@ -41,7 +41,7 @@ export const MessageAvatar: React.FC<MessageAvatarProps> = ({
     : null;
 
   const isTrustedAvatar =
-    avatarUrl && isUrlFromTrustedSource(avatarUrl, server?.filehost);
+    avatarUrl && isUrlFromTrustedSource(avatarUrl, serverFilehosts(server));
   const shouldShowAvatar =
     avatarUrl &&
     ((isTrustedAvatar && showSafeMedia) ||

--- a/src/components/message/MessageItem.tsx
+++ b/src/components/message/MessageItem.tsx
@@ -9,6 +9,7 @@ import {
   isUrlFromFilehost,
   isUserVerified,
   processMarkdownInText,
+  serverFilehosts,
 } from "../../lib/ircUtils";
 import {
   canShowMedia,
@@ -332,6 +333,10 @@ export const MessageItem = memo((props: MessageItemProps) => {
       [message.serverId],
     ),
   );
+  // Origins trusted for uploaded media: vendor obby.world/FILEHOST plus the
+  // tokenless draft/FILEHOST list. fileHostsKey is a stable memo dependency.
+  const fileHosts = serverFilehosts(server);
+  const fileHostsKey = fileHosts.join(" ");
   const mediaVisibilityLevel = useStore(
     useCallback((state) => state.globalSettings.mediaVisibilityLevel, []),
   );
@@ -407,9 +412,7 @@ export const MessageItem = memo((props: MessageItemProps) => {
   const isSingleToken = !/\s/.test(strippedContent.trim());
 
   // Kept for isFilehostImage prop passed to ImagePreview (EXIF banner)
-  const isFilehostUrl =
-    !!server?.filehost &&
-    isUrlFromFilehost(strippedContent.trim(), server.filehost);
+  const isFilehostUrl = isUrlFromFilehost(strippedContent.trim(), fileHosts);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: strippedContent derived from message.content
   const mediaEntries = useMemo(() => {
@@ -417,10 +420,10 @@ export const MessageItem = memo((props: MessageItemProps) => {
       canShowMedia(
         e.url,
         { showSafeMedia, showTrustedSourcesMedia, showExternalContent },
-        server?.filehost,
+        fileHosts,
       ),
     );
-  }, [strippedContent, mediaVisibilityLevel, server?.filehost]);
+  }, [strippedContent, mediaVisibilityLevel, fileHostsKey]);
 
   const [showAllImages, setShowAllImages] = useState(false);
 
@@ -738,10 +741,10 @@ export const MessageItem = memo((props: MessageItemProps) => {
                 <MediaPreview
                   entry={mediaEntries[0]}
                   msgid={message.msgid}
-                  isFilehostImage={
-                    !!server?.filehost &&
-                    isUrlFromFilehost(mediaEntries[0].url, server.filehost)
-                  }
+                  isFilehostImage={isUrlFromFilehost(
+                    mediaEntries[0].url,
+                    fileHosts,
+                  )}
                   serverId={message.serverId}
                   channelId={mediaChannelId}
                   onOpenProfile={onOpenProfile}
@@ -792,10 +795,10 @@ export const MessageItem = memo((props: MessageItemProps) => {
                     <MediaPreview
                       entry={mediaEntries[0]}
                       msgid={message.msgid}
-                      isFilehostImage={
-                        !!server?.filehost &&
-                        isUrlFromFilehost(mediaEntries[0].url, server.filehost)
-                      }
+                      isFilehostImage={isUrlFromFilehost(
+                        mediaEntries[0].url,
+                        fileHosts,
+                      )}
                       serverId={message.serverId}
                       channelId={mediaChannelId}
                       onOpenProfile={onOpenProfile}
@@ -818,13 +821,10 @@ export const MessageItem = memo((props: MessageItemProps) => {
                         key={firstKnownNotAtZero.url}
                         entry={firstKnownNotAtZero}
                         msgid={message.msgid}
-                        isFilehostImage={
-                          !!server?.filehost &&
-                          isUrlFromFilehost(
-                            firstKnownNotAtZero.url,
-                            server.filehost,
-                          )
-                        }
+                        isFilehostImage={isUrlFromFilehost(
+                          firstKnownNotAtZero.url,
+                          fileHosts,
+                        )}
                         serverId={message.serverId}
                         channelId={mediaChannelId}
                         onOpenProfile={onOpenProfile}
@@ -838,10 +838,10 @@ export const MessageItem = memo((props: MessageItemProps) => {
                               key={entry.url}
                               entry={entry}
                               msgid={message.msgid}
-                              isFilehostImage={
-                                !!server?.filehost &&
-                                isUrlFromFilehost(entry.url, server.filehost)
-                              }
+                              isFilehostImage={isUrlFromFilehost(
+                                entry.url,
+                                fileHosts,
+                              )}
                               serverId={message.serverId}
                               channelId={mediaChannelId}
                               onOpenProfile={onOpenProfile}

--- a/src/components/message/MessageReply.tsx
+++ b/src/components/message/MessageReply.tsx
@@ -18,6 +18,7 @@ const RiReplyFill = ({ className }: { className?: string }) => (
 );
 
 import { canShowImageUrl } from "../../lib/imageUtils";
+import { serverFilehosts } from "../../lib/ircUtils";
 import { imageCanHaveTransparency } from "../../lib/mediaUtils";
 import { stripIrcFormatting } from "../../lib/messageFormatter";
 import useStore from "../../store";
@@ -107,7 +108,7 @@ export const MessageReply: React.FC<MessageReplyProps> = ({
         canShowImageUrl(
           firstImageUrl,
           mediaVisibilityLevel,
-          server?.filehost,
+          serverFilehosts(server),
         ) && (
           <img
             src={firstImageUrl}

--- a/src/components/ui/ChannelListModal.tsx
+++ b/src/components/ui/ChannelListModal.tsx
@@ -5,7 +5,11 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { FaDesktop, FaHashtag, FaUsers, FaVolumeUp } from "react-icons/fa";
 import { useJoinAndSelectChannel } from "../../hooks/useJoinAndSelectChannel";
 import ircClient from "../../lib/ircClient";
-import { getChannelAvatarUrl, isUrlFromFilehost } from "../../lib/ircUtils";
+import {
+  getChannelAvatarUrl,
+  isUrlFromFilehost,
+  serverFilehosts,
+} from "../../lib/ircUtils";
 import { mediaLevelToSettings } from "../../lib/mediaUtils";
 import { BaseModal } from "../../lib/modal/BaseModal";
 import useStore from "../../store";
@@ -53,7 +57,7 @@ const ChannelListModal: React.FC = () => {
   const joinAndSelectChannel = useJoinAndSelectChannel();
 
   const selectedServer = servers.find((s) => s.id === selectedServerId);
-  const filehost = selectedServer?.filehost ?? "";
+  const filehost = serverFilehosts(selectedServer);
   const { showSafeMedia, showExternalContent } = mediaLevelToSettings(
     useStore((state) => state.globalSettings.mediaVisibilityLevel),
   );

--- a/src/components/ui/MediaCommentsSidebar.tsx
+++ b/src/components/ui/MediaCommentsSidebar.tsx
@@ -19,6 +19,7 @@ import { useScrollToBottom } from "../../hooks/useScrollToBottom";
 import { useTypingNotification } from "../../hooks/useTypingNotification";
 import { canShowImageUrl } from "../../lib/imageUtils";
 import ircClient from "../../lib/ircClient";
+import { serverFilehosts } from "../../lib/ircUtils";
 import {
   detectMediaType,
   getEmbedThumbnailUrl,
@@ -116,9 +117,9 @@ export function MediaCommentsSidebar({
   const { mediaVisibilityLevel, sendTypingNotifications } = useStore(
     (state) => state.globalSettings,
   );
-  const filehost = useStore
-    .getState()
-    .servers.find((s) => s.id === serverId)?.filehost;
+  const filehost = serverFilehosts(
+    useStore.getState().servers.find((s) => s.id === serverId),
+  );
 
   // Look up Channel object — useMessageSending needs channel.name for PRIVMSG target
   const selectedChannel = useStore((state) => {

--- a/src/components/ui/MediaViewerModal.tsx
+++ b/src/components/ui/MediaViewerModal.tsx
@@ -29,7 +29,7 @@ import {
 } from "react-icons/fa";
 import { useShallow } from "zustand/react/shallow";
 import { useMediaQuery } from "../../hooks/useMediaQuery";
-import { isUrlFromFilehost } from "../../lib/ircUtils";
+import { isUrlFromFilehost, serverFilehosts } from "../../lib/ircUtils";
 import { getCachedProbeResult, probeMediaUrl } from "../../lib/mediaProbe";
 import type { MediaEntry, MediaType } from "../../lib/mediaUtils";
 import {
@@ -562,9 +562,9 @@ export function MediaViewerModal({
       return;
     }
     const storeState = useStore.getState();
-    const filehost = storeState.servers.find(
-      (s) => s.id === serverId,
-    )?.filehost;
+    const filehost = serverFilehosts(
+      storeState.servers.find((s) => s.id === serverId),
+    );
     const mediaSettings = {
       showSafeMedia,
       showTrustedSourcesMedia,
@@ -1009,9 +1009,9 @@ export function MediaViewerModal({
       let idx = mediaEntries.findIndex((e) => e.url === imgUrl);
       if (idx < 0 && serverId && channelId) {
         // Image might be from a comment posted after modal opened — rebuild index
-        const filehost = useStore
-          .getState()
-          .servers.find((s) => s.id === serverId)?.filehost;
+        const filehost = serverFilehosts(
+          useStore.getState().servers.find((s) => s.id === serverId),
+        );
         const freshEntries = getChannelMessages(serverId, channelId)
           .flatMap((msg) =>
             extractMediaFromMessage(msg).map(

--- a/src/components/ui/TopicMediaStrip.tsx
+++ b/src/components/ui/TopicMediaStrip.tsx
@@ -1,6 +1,7 @@
 import type React from "react";
 import { useEffect, useMemo, useState } from "react";
 import { FaFileAlt, FaPlay } from "react-icons/fa";
+import { serverFilehosts } from "../../lib/ircUtils";
 import { getCachedProbeResult, probeMediaUrl } from "../../lib/mediaProbe";
 import type { MediaEntry, MediaType } from "../../lib/mediaUtils";
 import {
@@ -39,7 +40,7 @@ export const TopicMediaStrip: React.FC = () => {
   const topic = selectedChannel?.topic ?? null;
 
   const filehost = useMemo(
-    () => servers.find((s) => s.id === selectedServerId)?.filehost ?? null,
+    () => serverFilehosts(servers.find((s) => s.id === selectedServerId)),
     [servers, selectedServerId],
   );
 

--- a/src/components/ui/UserProfileModal.tsx
+++ b/src/components/ui/UserProfileModal.tsx
@@ -16,7 +16,7 @@ import {
   FaUserCheck,
 } from "react-icons/fa";
 import ircClient from "../../lib/ircClient";
-import { isUrlFromFilehost } from "../../lib/ircUtils";
+import { isUrlFromFilehost, serverFilehosts } from "../../lib/ircUtils";
 import { mediaLevelToSettings } from "../../lib/mediaUtils";
 import { openExternalUrl } from "../../lib/openUrl";
 import useStore from "../../store";
@@ -201,7 +201,7 @@ const UserProfileModal: React.FC<UserProfileModalProps> = ({
   const pronouns = user?.metadata?.pronouns?.value;
 
   const isFilehostAvatar =
-    !!avatar && isUrlFromFilehost(avatar, server?.filehost ?? "");
+    !!avatar && isUrlFromFilehost(avatar, serverFilehosts(server));
   const canShowAvatar =
     !!avatar && ((isFilehostAvatar && showSafeMedia) || showExternalContent);
 

--- a/src/lib/imageUtils.ts
+++ b/src/lib/imageUtils.ts
@@ -17,7 +17,7 @@ export function extractImageUrlsFromMessage(message: Message): string[] {
 export function canShowImageUrl(
   url: string,
   level: MediaVisibilityLevel,
-  filehost?: string | null,
+  filehost?: string | string[] | null,
 ): boolean {
   // Trusted-sources (level 2) covers embedded services, not arbitrary images,
   // so showTrustedSourcesMedia is intentionally false for image-only contexts.

--- a/src/lib/ircUtils.tsx
+++ b/src/lib/ircUtils.tsx
@@ -1041,31 +1041,49 @@ export function hasOpPermission(userStatus?: string): boolean {
 }
 
 /**
- * Check if a URL is from a specific filehost using proper URL parsing
- * This is safer than using string.startsWith() as it properly handles URL components
+ * True if `url` is served by one of the given filehost(s). Matching is on
+ * origin (protocol + host + port) only: a filehost serves its files from the
+ * domain root even when its upload endpoint sits under a path (e.g. the
+ * tokenless draft/FILEHOST endpoint `https://host/api/` returns files at
+ * `https://host/xyz`), so the path must be ignored. Accepts a single host or
+ * a list.
  */
 export function isUrlFromFilehost(
-  avatarUrl: string,
-  filehost: string,
+  url: string,
+  filehost: string | string[] | null | undefined,
 ): boolean {
-  if (!avatarUrl || !filehost) return false;
-
+  if (!url || !filehost) return false;
+  let urlOrigin: string;
   try {
-    const avatarUrlObj = new URL(avatarUrl);
-    const filehostUrl = new URL(filehost);
-
-    // Check if origins match (protocol + host + port)
-    if (avatarUrlObj.origin !== filehostUrl.origin) {
-      return false;
-    }
-
-    // Check if the pathname starts with the filehost pathname
-    // This handles cases where filehost might be a subdirectory
-    return avatarUrlObj.pathname.startsWith(filehostUrl.pathname);
+    urlOrigin = new URL(url).origin;
   } catch {
-    // If URL parsing fails, fall back to false
     return false;
   }
+  const hosts = Array.isArray(filehost) ? filehost : [filehost];
+  return hosts.some((h) => {
+    if (!h) return false;
+    try {
+      return new URL(h).origin === urlOrigin;
+    } catch {
+      return false;
+    }
+  });
+}
+
+/**
+ * Every origin a server trusts for uploaded media: the vendor
+ * obby.world/FILEHOST endpoint plus the tokenless draft/FILEHOST list. Pass
+ * the result wherever a filehost is needed for media-trust checks so both
+ * upload mechanisms are covered.
+ */
+export function serverFilehosts(
+  server?: { filehost?: string; fileHosts?: string[] } | null,
+): string[] {
+  if (!server) return [];
+  const hosts: string[] = [];
+  if (server.filehost) hosts.push(server.filehost);
+  if (server.fileHosts) hosts.push(...server.fileHosts);
+  return hosts;
 }
 
 /**
@@ -1074,7 +1092,7 @@ export function isUrlFromFilehost(
  */
 export function isUrlFromTrustedSource(
   url: string,
-  serverFilehost?: string,
+  serverFilehost?: string | string[],
 ): boolean {
   if (!url) return false;
 

--- a/src/lib/mediaUpload.ts
+++ b/src/lib/mediaUpload.ts
@@ -103,6 +103,83 @@ export function uploadFile(file: File, opts: UploadOptions): Promise<string> {
   });
 }
 
+export interface TokenlessUploadOptions {
+  /** Endpoint from draft/FILEHOST; we POST the file here as-is. */
+  endpoint: string;
+  onProgress?: (loaded: number, total: number) => void;
+  signal?: AbortSignal;
+}
+
+/**
+ * Upload via the standard tokenless IRCv3 draft/FILEHOST flow: POST the
+ * file (multipart `file` field) directly to an advertised endpoint, no auth.
+ *
+ * The spec returns 201 + a `Location` header, but real filehosts vary, so we
+ * accept (in order): the `Location` header, a JSON body with `url`/`saved_url`,
+ * or a plain-text URL body. Resolves with the file URL.
+ *
+ * Note: from a browser this only works if the endpoint serves CORS
+ * (`Access-Control-Allow-Origin`), and reading a 201 `Location` cross-origin
+ * additionally needs `Access-Control-Expose-Headers: Location`. Native clients
+ * have no such restriction.
+ */
+export function uploadFileTokenless(
+  file: File,
+  opts: TokenlessUploadOptions,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+
+    xhr.upload.addEventListener("progress", (e) => {
+      if (!e.lengthComputable) return;
+      opts.onProgress?.(e.loaded, e.total);
+    });
+
+    xhr.addEventListener("load", () => {
+      if (xhr.status < 200 || xhr.status >= 300) {
+        reject(xhr.responseText || `${xhr.status} ${xhr.statusText}`);
+        return;
+      }
+      const location = xhr.getResponseHeader("Location");
+      if (location) {
+        resolve(location);
+        return;
+      }
+      const text = (xhr.responseText || "").trim();
+      try {
+        const body = JSON.parse(text) as { url?: string; saved_url?: string };
+        const u = body.url ?? body.saved_url;
+        if (u) {
+          resolve(u);
+          return;
+        }
+      } catch {
+        // not JSON -- fall through to plain-text handling
+      }
+      if (/^https?:\/\/\S+$/.test(text)) {
+        resolve(text);
+        return;
+      }
+      reject("Filehost response did not include a URL");
+    });
+    xhr.addEventListener("error", () => reject("Network error during upload"));
+    xhr.addEventListener("abort", () => reject("Upload cancelled"));
+
+    if (opts.signal) {
+      if (opts.signal.aborted) {
+        reject("Upload cancelled");
+        return;
+      }
+      opts.signal.addEventListener("abort", () => xhr.abort());
+    }
+
+    xhr.open("POST", opts.endpoint);
+    const form = new FormData();
+    form.append("file", file);
+    xhr.send(form);
+  });
+}
+
 /**
  * Best-effort client-side validation against fetchUploadInfo() output.
  * Returns null when the file is OK; otherwise a human-readable reason

--- a/src/lib/mediaUpload.ts
+++ b/src/lib/mediaUpload.ts
@@ -111,6 +111,29 @@ export interface TokenlessUploadOptions {
 }
 
 /**
+ * Extract the uploaded file's URL from a draft/FILEHOST response. The spec
+ * uses the `Location` header (201), but real filehosts vary, so we accept
+ * (in order): the Location header, a JSON body with `url`/`saved_url`, or a
+ * plain-text URL body. Returns null when none is present.
+ */
+export function parseFilehostUploadResponse(
+  location: string | null,
+  body: string,
+): string | null {
+  if (location) return location;
+  const text = body.trim();
+  try {
+    const parsed = JSON.parse(text) as { url?: string; saved_url?: string };
+    const u = parsed.url ?? parsed.saved_url;
+    if (u) return u;
+  } catch {
+    // not JSON -- fall through to plain-text handling
+  }
+  if (/^https?:\/\/\S+$/.test(text)) return text;
+  return null;
+}
+
+/**
  * Upload via the standard tokenless IRCv3 draft/FILEHOST flow: POST the
  * file (multipart `file` field) directly to an advertised endpoint, no auth.
  *
@@ -140,24 +163,12 @@ export function uploadFileTokenless(
         reject(xhr.responseText || `${xhr.status} ${xhr.statusText}`);
         return;
       }
-      const location = xhr.getResponseHeader("Location");
-      if (location) {
-        resolve(location);
-        return;
-      }
-      const text = (xhr.responseText || "").trim();
-      try {
-        const body = JSON.parse(text) as { url?: string; saved_url?: string };
-        const u = body.url ?? body.saved_url;
-        if (u) {
-          resolve(u);
-          return;
-        }
-      } catch {
-        // not JSON -- fall through to plain-text handling
-      }
-      if (/^https?:\/\/\S+$/.test(text)) {
-        resolve(text);
+      const url = parseFilehostUploadResponse(
+        xhr.getResponseHeader("Location"),
+        xhr.responseText || "",
+      );
+      if (url) {
+        resolve(url);
         return;
       }
       reject("Filehost response did not include a URL");

--- a/src/lib/mediaUtils.ts
+++ b/src/lib/mediaUtils.ts
@@ -278,7 +278,7 @@ export function filenameFromUrl(url: string): string {
 export function canShowMedia(
   url: string,
   settings: MediaSettings,
-  filehost?: string | null,
+  filehost?: string | string[] | null,
 ): boolean {
   if (settings.showExternalContent) return true;
   if (settings.showSafeMedia) {

--- a/src/protocol/isupport.ts
+++ b/src/protocol/isupport.ts
@@ -90,6 +90,20 @@ export function registerISupportHandler(
       return;
     }
 
+    // Standard tokenless IRCv3 draft/FILEHOST: a space-separated list of
+    // upload endpoints the client POSTs to directly (no auth). parseIsupport
+    // has already turned \x20 back into spaces, so just split.
+    if (key === "draft/FILEHOST") {
+      const hosts = value.split(/\s+/).filter((u) => /^https?:\/\//i.test(u));
+      useStore.setState((state) => {
+        const updatedServers = state.servers.map((server: Server) =>
+          server.id === serverId ? { ...server, fileHosts: hosts } : server,
+        );
+        return { servers: updatedServers };
+      });
+      return;
+    }
+
     if (key === "ELIST") {
       useStore.setState((state) => {
         const updatedServers = state.servers.map((server: Server) => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -52,6 +52,9 @@ export interface Server {
   // POST to <filehost>/upload); the standard tokenless draft/FILEHOST is
   // discovered separately.
   filehost?: string;
+  // Endpoints from the standard tokenless `draft/FILEHOST` ISUPPORT token:
+  // POST the file directly, no auth, take the returned URL.
+  fileHosts?: string[];
   linkSecurity?: number; // Link security level from unrealircd.org/link-security
   jwtToken?: string; // JWT token for filehost authentication (from EXTJWT)
   // Bearer token from draft/authtoken (TOKEN GENERATE).  Used as the

--- a/tests/lib/mediaUpload.test.ts
+++ b/tests/lib/mediaUpload.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { parseFilehostUploadResponse } from "../../src/lib/mediaUpload";
+
+describe("parseFilehostUploadResponse (draft/FILEHOST)", () => {
+  it("prefers the Location header (spec 201 response)", () => {
+    expect(
+      parseFilehostUploadResponse(
+        "https://files.example/abc.png",
+        '{"url":"https://other.example/ignored.png"}',
+      ),
+    ).toBe("https://files.example/abc.png");
+  });
+
+  it("reads a JSON body with `url` (s.h4ks.com /api/ style)", () => {
+    expect(
+      parseFilehostUploadResponse(
+        null,
+        '{"status":"success","url":"https://s.h4ks.com/HqI.txt"}',
+      ),
+    ).toBe("https://s.h4ks.com/HqI.txt");
+  });
+
+  it("reads a JSON body with the legacy `saved_url`", () => {
+    expect(
+      parseFilehostUploadResponse(null, '{"saved_url":"https://x.example/y"}'),
+    ).toBe("https://x.example/y");
+  });
+
+  it("reads a plain-text URL body (s.h4ks.com root style)", () => {
+    expect(
+      parseFilehostUploadResponse(null, "https://s.h4ks.com/HqK.txt\n"),
+    ).toBe("https://s.h4ks.com/HqK.txt");
+  });
+
+  it("returns null when no URL is present", () => {
+    expect(parseFilehostUploadResponse(null, "")).toBeNull();
+    expect(parseFilehostUploadResponse(null, "not a url")).toBeNull();
+    expect(parseFilehostUploadResponse(null, '{"status":"error"}')).toBeNull();
+  });
+
+  it("ignores a non-http(s) plain-text body", () => {
+    expect(
+      parseFilehostUploadResponse(null, "ftp://nope.example/x"),
+    ).toBeNull();
+  });
+});

--- a/tests/lib/mediaUtils.test.ts
+++ b/tests/lib/mediaUtils.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import { serverFilehosts } from "../../src/lib/ircUtils";
 import {
   canShowMedia,
   detectMediaType,
@@ -356,6 +357,73 @@ describe("canShowMedia", () => {
         null,
       ),
     ).toBe(false);
+  });
+});
+
+describe("canShowMedia — filehost trust is origin-based", () => {
+  const settings = {
+    showSafeMedia: true,
+    showTrustedSourcesMedia: false,
+    showExternalContent: false,
+  };
+
+  // girafiles: the upload endpoint is https://host/api/ but files are served
+  // from the host root, so trust must ignore the filehost's path.
+  test("trusts a root file when the filehost endpoint has a path", () => {
+    expect(
+      canShowMedia(
+        "https://s.h4ks.com/HrE.txt",
+        settings,
+        "https://s.h4ks.com/api/",
+      ),
+    ).toBe(true);
+  });
+
+  test("still denies a different origin when the filehost has a path", () => {
+    expect(
+      canShowMedia(
+        "https://evil.com/x.jpg",
+        settings,
+        "https://s.h4ks.com/api/",
+      ),
+    ).toBe(false);
+  });
+
+  test("accepts a list of filehosts (vendor + tokenless)", () => {
+    expect(
+      canShowMedia("https://s.h4ks.com/HrE.txt", settings, [
+        "https://obby.t3ks.com",
+        "https://s.h4ks.com/api/",
+      ]),
+    ).toBe(true);
+  });
+
+  test("an empty filehost list trusts nothing under safe-media", () => {
+    expect(canShowMedia("https://s.h4ks.com/x.txt", settings, [])).toBe(false);
+  });
+});
+
+describe("serverFilehosts", () => {
+  test("combines the vendor filehost and the tokenless fileHosts", () => {
+    expect(
+      serverFilehosts({
+        filehost: "https://obby.t3ks.com",
+        fileHosts: ["https://s.h4ks.com/api/", "https://x.example/"],
+      }),
+    ).toEqual([
+      "https://obby.t3ks.com",
+      "https://s.h4ks.com/api/",
+      "https://x.example/",
+    ]);
+  });
+
+  test("tolerates missing fields and no server", () => {
+    expect(serverFilehosts({ fileHosts: ["https://b"] })).toEqual([
+      "https://b",
+    ]);
+    expect(serverFilehosts({ filehost: "https://a" })).toEqual(["https://a"]);
+    expect(serverFilehosts({})).toEqual([]);
+    expect(serverFilehosts(undefined)).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

Stacked on #219 (the `draft/authtoken` + `obby.world/FILEHOST` vendor rename). Adds support for the **standard tokenless `draft/FILEHOST`** and fixes filehost media trust to be origin-based.

> Base branch is `feat/uploaders-draft-authtoken` (#219); GitHub will retarget to the default branch once #219 merges.

## Tokenless `draft/FILEHOST`

- **`isupport.ts`** — `draft/FILEHOST` → `server.fileHosts[]` (a space-separated list of upload endpoints; `parseIsupport` has already un-escaped `\x20`).
- **`mediaUpload.ts`** — `uploadFileTokenless()` POSTs the file (multipart `file` field) directly to an advertised endpoint, **no auth**. Resolves the URL from the spec's `Location` header, else a JSON `{url}`/`{saved_url}` body, else a plain-text URL body (covers girafiles/s.h4ks.com, which returns `200 + {"url":…}`).
- **`ChatArea`** — prefer the tokenless endpoint when offered, else the vendor token path; no token mint / policy pre-flight on the tokenless path. `canUpload` now gates the picker + drag-drop on either mechanism. A server is expected to advertise one mechanism or the other, not both.

Browser uploads to an external host require CORS (`Access-Control-Allow-Origin`) on that host; native clients are unrestricted.

## Media-trust fix

Uploaded files are served from the filehost's domain **root**, but the trust check matched the full filehost value *including its path* — so when `draft/FILEHOST` advertises a path endpoint (e.g. `https://host/api/`), files at `https://host/xyz` failed and wouldn't render.

- `isUrlFromFilehost` now matches on **origin** only (path ignored) and accepts a single host or a list.
- New `serverFilehosts(server)` folds the tokenless `fileHosts` in alongside the vendor `filehost`, threaded through every media/avatar trust site (the old `!!server?.filehost &&` guards short-circuited when only `fileHosts` was set; one site even used a raw `startsWith`).

## Server companion

`draft/FILEHOST` is advertised by obbyircd via a new `external` config directive (ObbyIRCd branch `feat/obby-world-filehost`):

```
filehosts {
    host 'https://obby.t3ks.com';        # account-gated -> obby.world/FILEHOST
    external 'https://s.h4ks.com/api/';  # tokenless     -> draft/FILEHOST
}
```

## Tests

- `parseFilehostUploadResponse`: `Location` / JSON `{url}`,`{saved_url}` / plain-text precedence.
- Origin-based trust: root file under a `/api/` filehost, host lists, `serverFilehosts`.
- Full suite green; `tsc` + `vite build` clean.

## Test plan

- [x] tsc + build + tests
- [ ] Browser: tokenless upload to s.h4ks.com → URL posted + renders inline
- [ ] Native app: upload (no CORS needed)
