### PR TITLE
fix: send WHO on JOIN regardless of chathistory state

### DIFF
--- a/src/lib/irc/IRCClient.ts
+++ b/src/lib/irc/IRCClient.ts
@@ -1190,13 +1190,17 @@ export class IRCClient implements IRCClientContext {
       };
       server.channels.push(channel);
 
-      // Trigger event to notify store that history loading started (only if we actually requested it)
       if (server.capabilities?.includes("draft/chathistory")) {
         this.triggerEvent("CHATHISTORY_LOADING", {
           serverId,
           channelName,
           isLoading: true,
         });
+      } else {
+        // No CHATHISTORY support, so the LOADING(false) callback that
+        // normally fires WHO will never run. Send it now.
+        this.sendRaw(serverId, `WHO ${channelName} %cuhnfaro`);
+        channel.needsWhoRequest = false;
       }
 
       return channel;

--- a/src/store/handlers/users.ts
+++ b/src/store/handlers/users.ts
@@ -860,6 +860,17 @@ export function registerUserHandlers(store: StoreApi<AppState>): void {
       target,
       serverId,
     });
+    // A CHATHISTORY FAIL never opens a batch, so the LOADING(false)
+    // event that normally chains the WHO request will never fire on
+    // its own. Synthesise it here so the channel doesn't stay
+    // permanently flagged needsWhoRequest=true.
+    if (command === "CHATHISTORY" && target && target.startsWith("#")) {
+      ircClient.triggerEvent("CHATHISTORY_LOADING", {
+        serverId,
+        channelName: target,
+        isLoading: false,
+      });
+    }
   });
 
   ircClient.on(


### PR DESCRIPTION
## Summary

The channel `WHO` request currently chains to `CHATHISTORY_LOADING(isLoading=false)`. That event only ever fires when the server (a) advertises `draft/chathistory` AND (b) actually returns a batch in response. Two real leaks:

- **No `draft/chathistory` cap at all** (older charybdis/hybrid/some inspircd builds) → loading-true is gated on the cap so it never starts → loading-false never arrives → `needsWhoRequest=true` is set forever → member list never populates.
- **Cap present, but `FAIL CHATHISTORY`** (member-race on the join, missing channel, +H mode disabled per config) → loading-true fires, no `BATCH` ever opens, loading-false never chains either → same leak.

Ergo works because it advertises the cap and always returns a batch.

## Changes

- [`src/lib/irc/IRCClient.ts`](src/lib/irc/IRCClient.ts) — when `joinChannel` sees the cap is absent, send `WHO #channel %cuhnfaro` immediately and clear `needsWhoRequest`. The chathistory branch is untouched.
- [`src/store/handlers/users.ts`](src/store/handlers/users.ts) — when a `FAIL CHATHISTORY` arrives for a channel, synthesise the `CHATHISTORY_LOADING(false)` event so the existing WHO-on-loading-end chain still runs.

## Test plan

- [ ] Tests: `npm run test` (800/801 passing locally)
- [ ] Build clean: `npm run build`
- [ ] Connect to an Ergo server, JOIN a channel → member list populates (existing path, no regression)
- [ ] Connect to a server WITHOUT `draft/chathistory` → JOIN a channel → member list populates (was empty before)
- [ ] Connect to a server WITH `draft/chathistory` but trigger a FAIL (e.g. join a fresh channel with +H disabled) → member list still populates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved chat history loading for IRC servers without draft/chathistory support.
  * Fixed channels remaining stuck in loading state when chat history requests fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->