### PR TITLE
fix(join): fire CHATHISTORY/WHO on server-initiated own JOIN

### DIFF
--- a/src/store/handlers/channels.ts
+++ b/src/store/handlers/channels.ts
@@ -405,7 +405,7 @@ export function registerChannelHandlers(store: StoreApi<AppState>): void {
         }
         return server;
       });
-      
+
       // Check if current user has operator status in this channel and update their modes
       const currentUser = state.currentUser;
       if (currentUser) {

--- a/src/store/handlers/users.ts
+++ b/src/store/handlers/users.ts
@@ -110,9 +110,13 @@ export function registerUserHandlers(store: StoreApi<AppState>): void {
       const isOurJoin = username === ourNick;
 
       if (isOurJoin) {
-        // Ensure the channel exists in the store; joinChannel action usually handles this,
-        // but this catches cases where the server JOIN confirmation arrives without a prior joinChannel call.
-        // Don't add ourselves to the member list — NAMES populates it with proper modes.
+        // Server-initiated JOIN (Unreal persistence, sajoin, perform list,
+        // perform-on-connect): joinChannel() never ran, so the CHATHISTORY
+        // + WHO chain that normally lives inside it was never kicked off.
+        // Mirror joinChannel's tail here for the channel-doesn't-exist case
+        // so the nicklist actually populates. Don't add ourselves to the
+        // member list — NAMES populates it with proper modes.
+        let newChannelHadCap: boolean | null = null;
         store.setState((state) => {
           const server = state.servers.find((s) => s.id === serverId);
           if (!server) return {};
@@ -121,6 +125,10 @@ export function registerUserHandlers(store: StoreApi<AppState>): void {
             (c) => c.name.toLowerCase() === channelName.toLowerCase(),
           );
           if (exists) return {};
+
+          const hasChathistory =
+            !!server.capabilities?.includes("draft/chathistory");
+          newChannelHadCap = hasChathistory;
 
           return {
             servers: state.servers.map((s) => {
@@ -138,13 +146,28 @@ export function registerUserHandlers(store: StoreApi<AppState>): void {
                     isMentioned: false,
                     messages: [],
                     users: [],
-                    needsWhoRequest: true,
+                    isLoadingHistory: hasChathistory,
+                    hasMoreHistory: hasChathistory,
+                    needsWhoRequest: !!hasChathistory,
+                    chathistoryRequested: hasChathistory,
                   },
                 ],
               };
             }),
           };
         });
+        // ircClient I/O OUTSIDE setState: triggerEvent inside setState
+        // causes a nested-setState race (see batches.ts:215-218).
+        if (newChannelHadCap === true) {
+          ircClient.sendRaw(serverId, `CHATHISTORY LATEST ${channelName} * 50`);
+          ircClient.triggerEvent("CHATHISTORY_LOADING", {
+            serverId,
+            channelName,
+            isLoading: true,
+          });
+        } else if (newChannelHadCap === false) {
+          ircClient.sendRaw(serverId, `WHO ${channelName} %cuhnfaro`);
+        }
         // Fall through to shared message creation below — same JOIN event, same path.
       } else {
         store.setState((state) => {

--- a/tests/store/join.test.ts
+++ b/tests/store/join.test.ts
@@ -228,10 +228,8 @@ describe("server-initiated own-JOIN — CHATHISTORY/WHO fanout", () => {
     ircClient.sendRaw = (id: string, line: string) => sent.push(line);
 
     const loadings: { channel: string; isLoading: boolean }[] = [];
-    ircClient.on(
-      "CHATHISTORY_LOADING",
-      ({ channelName, isLoading }) =>
-        loadings.push({ channel: channelName, isLoading }),
+    ircClient.on("CHATHISTORY_LOADING", ({ channelName, isLoading }) =>
+      loadings.push({ channel: channelName, isLoading }),
     );
 
     ircClient.triggerEvent("JOIN", {

--- a/tests/store/join.test.ts
+++ b/tests/store/join.test.ts
@@ -190,3 +190,132 @@ describe("readyProcessedServers — reconnect guard", () => {
     expect(readyProcessedServers.has("srv-1")).toBe(true);
   });
 });
+
+describe("server-initiated own-JOIN — CHATHISTORY/WHO fanout", () => {
+  function setupServerWithCaps(caps: string[]) {
+    useStore.setState({
+      servers: [
+        {
+          id: "srv-1",
+          name: "TestServer",
+          host: "irc.example.com",
+          port: 6667,
+          channels: [],
+          privateChats: [],
+          isConnected: true,
+          users: [],
+          capabilities: caps,
+        },
+      ],
+      messages: {},
+      activeBatches: {},
+      globalSettings: {
+        showEvents: true,
+        showJoinsParts: true,
+      },
+    } as unknown as AppState);
+    ircClient.nicks.set("srv-1", "me");
+  }
+
+  beforeEach(() => {
+    ircClient.nicks.delete("srv-1");
+  });
+
+  it("draft/chathistory cap: requests CHATHISTORY + triggers LOADING(true), leaves needsWhoRequest=true for the batch close to clear", () => {
+    setupServerWithCaps(["draft/chathistory", "message-tags"]);
+    const sent: string[] = [];
+    const origSendRaw = ircClient.sendRaw.bind(ircClient);
+    ircClient.sendRaw = (id: string, line: string) => sent.push(line);
+
+    const loadings: { channel: string; isLoading: boolean }[] = [];
+    ircClient.on(
+      "CHATHISTORY_LOADING",
+      ({ channelName, isLoading }) =>
+        loadings.push({ channel: channelName, isLoading }),
+    );
+
+    ircClient.triggerEvent("JOIN", {
+      serverId: "srv-1",
+      username: "me",
+      channelName: "#unreal-support",
+    });
+
+    ircClient.sendRaw = origSendRaw;
+
+    const ch = useStore
+      .getState()
+      .servers.find((s) => s.id === "srv-1")
+      ?.channels.find((c) => c.name === "#unreal-support");
+    expect(ch).toBeDefined();
+    expect(ch?.needsWhoRequest).toBe(true);
+    expect(ch?.chathistoryRequested).toBe(true);
+    expect(ch?.isLoadingHistory).toBe(true);
+    expect(sent).toContain("CHATHISTORY LATEST #unreal-support * 50");
+    expect(sent.some((l) => l.startsWith("WHO "))).toBe(false);
+    expect(loadings).toContainEqual({
+      channel: "#unreal-support",
+      isLoading: true,
+    });
+  });
+
+  it("no chathistory cap: sends WHO immediately, marks needsWhoRequest=false", () => {
+    setupServerWithCaps(["message-tags"]);
+    const sent: string[] = [];
+    const origSendRaw = ircClient.sendRaw.bind(ircClient);
+    ircClient.sendRaw = (id: string, line: string) => sent.push(line);
+
+    ircClient.triggerEvent("JOIN", {
+      serverId: "srv-1",
+      username: "me",
+      channelName: "#inspircd-help",
+    });
+
+    ircClient.sendRaw = origSendRaw;
+
+    const ch = useStore
+      .getState()
+      .servers.find((s) => s.id === "srv-1")
+      ?.channels.find((c) => c.name === "#inspircd-help");
+    expect(ch).toBeDefined();
+    expect(ch?.needsWhoRequest).toBe(false);
+    expect(ch?.chathistoryRequested).toBe(false);
+    expect(ch?.isLoadingHistory).toBe(false);
+    expect(sent).toContain("WHO #inspircd-help %cuhnfaro");
+    expect(sent.some((l) => l.startsWith("CHATHISTORY "))).toBe(false);
+  });
+
+  it("channel already exists (joinChannel ran first): does NOT double-send CHATHISTORY/WHO", () => {
+    setupServerWithCaps(["draft/chathistory"]);
+    useStore.setState((state) => ({
+      servers: state.servers.map((s) =>
+        s.id === "srv-1"
+          ? {
+              ...s,
+              channels: [
+                makeChannel({
+                  name: "#preexisting",
+                  chathistoryRequested: true,
+                  isLoadingHistory: true,
+                  needsWhoRequest: true,
+                }),
+              ],
+            }
+          : s,
+      ),
+    }));
+    const sent: string[] = [];
+    const origSendRaw = ircClient.sendRaw.bind(ircClient);
+    ircClient.sendRaw = (id: string, line: string) => sent.push(line);
+
+    ircClient.triggerEvent("JOIN", {
+      serverId: "srv-1",
+      username: "me",
+      channelName: "#preexisting",
+    });
+
+    ircClient.sendRaw = origSendRaw;
+
+    expect(sent.some((l) => l.startsWith("CHATHISTORY "))).toBe(false);
+    expect(sent.some((l) => l.startsWith("WHO "))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Empty-nicklist-on-Unreal/InspIRCd bug that **#248** addressed for one entry point and missed for the other. Reproduced on UnrealIRCd Support; confirmed root cause via Raw IRC Log Viewer (no `CHATHISTORY` was sent, no `WHO` was sent) and recovery via manual `/WHO #chan %cuhnfaro`.

## Diagnosis

The JOIN → CHATHISTORY → WHO chain lives **inside** `IRCClient.joinChannel()`. When the *server* auto-joins us — UnrealIRCd persistence module, sajoin, operblock perform-on-connect, InspIRCd auto-join — `joinChannel()` never runs. The JOIN handler at [`users.ts:115-147`](src/store/handlers/users.ts#L115-L147) created the channel entry with `needsWhoRequest: true` and stopped there. Nothing downstream cleared the flag; nicklist stayed empty forever.

Why **Ergo** never showed this even though it auto-joins too: Ergo's auto-join sends a `draft/chathistory` BATCH alongside the JOIN, so the batch close fires `CHATHISTORY_LOADING(false)` → [`messages.ts:2028`](src/store/handlers/messages.ts#L2028) sees `needsWhoRequest=true` → WHO goes out. UnrealIRCd and InspIRCd don't send a batch on auto-join, so nothing kicks the chain.

## Fix

Mirror `joinChannel`'s tail in the own-join + new-channel branch:

- `draft/chathistory` cap present → send `CHATHISTORY LATEST #chan * 50` + trigger `CHATHISTORY_LOADING(true)`; existing batch-close → WHO path then runs.
- Cap absent (InspIRCd networks without the module) → send `WHO #chan %cuhnfaro` immediately, clear `needsWhoRequest`.

`ircClient` I/O runs **outside** the `setState` callback — `triggerEvent` inside `setState` causes the nested-setState clobber that [`batches.ts:215-218`](src/store/handlers/batches.ts#L215-L218) already documents.

## Test plan

- [x] Unit: cap-present branch sends CHATHISTORY + LOADING(true), leaves `needsWhoRequest=true`
- [x] Unit: cap-absent branch sends WHO immediately, clears `needsWhoRequest`
- [x] Unit: `joinChannel` already ran (channel exists) → no double-send
- [x] Manual on the bugged UnrealIRCd Support session: server-initiated auto-join now populates the nicklist without `/WHO`
- [x] Manual on InspIRCd network: same
- [x] Manual on Ergo: still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when the server signals you've joined a channel: chat history is now loaded automatically if supported, otherwise user info is requested so channels initialize correctly.
* **Tests**
  * Added tests covering server-initiated self-joins to ensure history-loading and fallback behavior behave correctly and aren’t duplicated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->